### PR TITLE
Introduce `--webnn-use-ort` switch for testing

### DIFF
--- a/content/browser/gpu/gpu_process_host.cc
+++ b/content/browser/gpu/gpu_process_host.cc
@@ -326,6 +326,9 @@ static const char* const kSwitchNames[] = {
 #if BUILDFLAG(WEBNN_USE_TFLITE)
     switches::kWebNNTfliteDumpModel,
 #endif
+#if BUILDFLAG(WEBNN_USE_ORT)
+    switches::kWebNNUseOrt,
+#endif
 };
 
 // These values are persisted to logs. Entries should not be renumbered and

--- a/services/webnn/BUILD.gn
+++ b/services/webnn/BUILD.gn
@@ -13,6 +13,7 @@ buildflag_header("buildflags") {
   flags = [
     "WEBNN_USE_TFLITE=$webnn_use_tflite",
     "WEBNN_ENABLE_TFLITE_PROFILER=$webnn_enable_tflite_profiler",
+    "WEBNN_USE_ORT=$webnn_use_ort",
   ]
 }
 
@@ -70,32 +71,10 @@ component("webnn_service") {
       "dml/tensor_impl_dml.h",
       "dml/utils.cc",
       "dml/utils.h",
-      "ort/allocator_ort.cc",
-      "ort/allocator_ort.h",
-      "ort/buffer_content_ort.cc",
-      "ort/buffer_content_ort.h",
-      "ort/context_impl_ort.cc",
-      "ort/context_impl_ort.h",
-      "ort/error_ort.h",
-      "ort/graph_builder_ort.cc",
-      "ort/graph_builder_ort.h",
-      "ort/graph_impl_ort.cc",
-      "ort/graph_impl_ort.h",
-      "ort/ort_model_builder.cc",
-      "ort/ort_model_builder.h",
-      "ort/platform_functions_ort.cc",
-      "ort/platform_functions_ort.h",
-      "ort/scoped_ort_types.cc",
-      "ort/scoped_ort_types.h",
-      "ort/tensor_impl_ort.cc",
-      "ort/tensor_impl_ort.h",
-      "ort/utils_ort.cc",
-      "ort/utils_ort.h",
     ]
     deps += [
       "//third_party/fp16",
       "//third_party/microsoft_dxheaders:dxguids",
-      "//third_party/onnxruntime_headers",
       "//ui/gl",
       "//ui/gl/init",
     ]
@@ -158,7 +137,34 @@ component("webnn_service") {
     }
   }
 
-  if (webnn_use_tflite || is_mac) {
+  if (webnn_use_ort) {
+    sources += [
+      "ort/allocator_ort.cc",
+      "ort/allocator_ort.h",
+      "ort/buffer_content_ort.cc",
+      "ort/buffer_content_ort.h",
+      "ort/context_impl_ort.cc",
+      "ort/context_impl_ort.h",
+      "ort/error_ort.h",
+      "ort/graph_builder_ort.cc",
+      "ort/graph_builder_ort.h",
+      "ort/graph_impl_ort.cc",
+      "ort/graph_impl_ort.h",
+      "ort/ort_model_builder.cc",
+      "ort/ort_model_builder.h",
+      "ort/platform_functions_ort.cc",
+      "ort/platform_functions_ort.h",
+      "ort/scoped_ort_types.cc",
+      "ort/scoped_ort_types.h",
+      "ort/tensor_impl_ort.cc",
+      "ort/tensor_impl_ort.h",
+      "ort/utils_ort.cc",
+      "ort/utils_ort.h",
+    ]
+    deps += [ "//third_party/onnxruntime_headers" ]
+  }
+
+  if (webnn_use_tflite || is_mac || webnn_use_ort) {
     sources += [
       "queueable_resource_state.h",
       "queueable_resource_state_base.cc",

--- a/services/webnn/features.gni
+++ b/services/webnn/features.gni
@@ -9,4 +9,7 @@ declare_args() {
 
   # Enable logging of TFLite profiling information on MLGraph destruction.
   webnn_enable_tflite_profiler = false
+
+  # Enable the experimental ONNX Runtime backend on Windows.
+  webnn_use_ort = is_win
 }

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -22,7 +22,6 @@
 #include "services/webnn/resource_task.h"
 #include "services/webnn/webnn_constant_operand.h"
 #include "services/webnn/webnn_graph_impl.h"
-#include "third_party/onnxruntime_headers/src/include/onnxruntime/core/providers/dml/dml_provider_factory.h"
 
 namespace webnn::ort {
 
@@ -109,27 +108,7 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
   CHECK_STATUS(ort_api->SetSessionGraphOptimizationLevel(
       session_options, GraphOptimizationLevel::ORT_ENABLE_BASIC));
 
-  if (context_options->device == mojom::CreateContextOptions::Device::kGpu ||
-      context_options->device == mojom::CreateContextOptions::Device::kNpu) {
-    const OrtDmlApi* ort_dml_api;
-    CHECK_STATUS(ort_api->GetExecutionProviderApi(
-        "DML", 10, reinterpret_cast<const void**>(&ort_dml_api)));
-
-    OrtDmlDeviceOptions options;
-    if (context_options->device == mojom::CreateContextOptions::Device::kGpu) {
-      options = {OrtDmlPerformancePreference::HighPerformance,
-                 OrtDmlDeviceFilter::Gpu};
-    } else {
-      options = {OrtDmlPerformancePreference::MinimumPower,
-                 OrtDmlDeviceFilter::Gpu};
-      // NPU is available only when ENABLE_NPU_ADAPTER_ENUMERATION
-      // options = {OrtDmlPerformancePreference::MinimumPower,
-      // OrtDmlDeviceFilter::Npu};
-    }
-
-    ort_dml_api->SessionOptionsAppendExecutionProvider_DML2(session_options,
-                                                            &options);
-  }
+  // TODO: Append OpenVINO EP for GPU and NPU devices.
 
   OrtSession* session;
   const OrtEnv* env = allocator->env();

--- a/services/webnn/ort/platform_functions_ort.cc
+++ b/services/webnn/ort/platform_functions_ort.cc
@@ -19,11 +19,10 @@ PlatformFunctions::PlatformFunctions() {
     ort_library = base::ScopedNativeLibrary(base::LoadNativeLibrary(
         module_path.Append(L"onnxruntime.dll"), nullptr));
   }
-  // Dll from system folder doesn't support OrtGraph API.
-  // if (!ort_library.is_valid()) {
-  //   ort_library =
-  //       base::ScopedNativeLibrary(base::LoadSystemLibrary(L"onnxruntime.dll"));
-  // }
+  if (!ort_library.is_valid()) {
+    ort_library =
+        base::ScopedNativeLibrary(base::LoadSystemLibrary(L"onnxruntime.dll"));
+  }
   if (!ort_library.is_valid()) {
     LOG(ERROR) << "[WebNN] Failed to load onnxruntime.dll.";
     return;
@@ -42,7 +41,8 @@ PlatformFunctions::PlatformFunctions() {
   // `OrtApiBase::OrtApi()`.
   const OrtApi* ort_api = ort_get_api_base_proc()->GetApi(ORT_API_VERSION);
   if (!ort_api) {
-    LOG(ERROR) << "[WebNN] Failed to get OrtApi.";
+    LOG(ERROR) << "[WebNN] Failed to get OrtApi for API Version "
+               << ORT_API_VERSION;
     return;
   }
 

--- a/services/webnn/webnn_context_provider_impl.cc
+++ b/services/webnn/webnn_context_provider_impl.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/check_is_test.h"
+#include "base/command_line.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/types/expected_macros.h"
 #include "mojo/public/cpp/bindings/self_owned_receiver.h"
@@ -27,8 +28,11 @@
 #include "services/webnn/dml/command_recorder.h"
 #include "services/webnn/dml/context_impl_dml.h"
 #include "services/webnn/dml/utils.h"
+#if BUILDFLAG(WEBNN_USE_ORT)
 #include "services/webnn/ort/context_impl_ort.h"
 #include "services/webnn/ort/platform_functions_ort.h"
+#include "services/webnn/webnn_switches.h"
+#endif
 #endif
 
 #if BUILDFLAG(IS_MAC)
@@ -231,9 +235,9 @@ void WebNNContextProviderImpl::CreateWebNNContext(
 
   RecordDeviceType(options->device);
 
-#if BUILDFLAG(IS_WIN)
-  if (options->power_preference ==
-          mojom::CreateContextOptions::PowerPreference::kLowPower) {
+#if BUILDFLAG(WEBNN_USE_ORT)
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kWebNNUseOrt)) {
     auto* platform_functions = ort::PlatformFunctions::GetInstance();
     if (!platform_functions) {
       std::move(callback).Run(ToError<mojom::CreateContextResult>(
@@ -253,7 +257,11 @@ void WebNNContextProviderImpl::CreateWebNNContext(
     context_impl =
         new ort::ContextImplOrt(std::move(receiver), this, std::move(options),
                                 std::move(allocator_ort));
-  } else if (ShouldCreateDmlContext(*options)) {
+  }
+#endif  // BUILDFLAG(WEBNN_USE_ORT)
+
+#if BUILDFLAG(IS_WIN)
+  if (!context_impl && ShouldCreateDmlContext(*options)) {
     DCHECK(gpu_feature_info_.IsInitialized());
     if (gpu_feature_info_.status_values[gpu::GPU_FEATURE_TYPE_WEBNN] !=
         gpu::kGpuFeatureStatusEnabled) {

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -26,6 +26,10 @@ inline constexpr char kWebNNCoreMlDumpModel[] = "webnn-coreml-dump-model";
 inline constexpr char kWebNNTfliteDumpModel[] = "webnn-tflite-dump-model";
 #endif  // BUILDFLAG(WEBNN_USE_TFLITE)
 
+#if BUILDFLAG(WEBNN_USE_ORT)
+inline constexpr char kWebNNUseOrt[] = "webnn-use-ort";
+#endif  // BUILDFLAG(WEBNN_USE_ORT)
+
 }  // namespace switches
 
 #endif  // SERVICES_WEBNN_WEBNN_SWITCHES_H_


### PR DESCRIPTION
Introduce `--webnn-use-ort` switch. When it is enabled, it overrides DirectML backend. At the current stage, the default CPU EP is used for all context device types.

Usage
```shell
$ chrome.exe --webnn-use-ort --use-redist-ort
```

Other changes include
1. Introduce webnn_use_ort build flag and enable it for Windows
2. Remove the non-working DML EP code path
3. Allow loading onnxruntime.dll from system folder