### PR TITLE
Using raw/external data depends on the data size and if used for shape inference

### DIFF
--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -89,6 +89,9 @@ constexpr char kOpTypeWhere[] = "Where";
 
 // constexpr char kBuildGraphError[] = "Failed to build graph.";
 
+// Define the minimum size(in bytes) to use external data.
+constexpr size_t kMinExternalDataSize = 128;
+
 base::unexpected<mojom::ErrorPtr> NewNotSupportedError(std::string message) {
   return base::unexpected(mojom::Error::New(
       mojom::Error::Code::kNotSupportedError, std::move(message)));
@@ -241,15 +244,26 @@ std::string GraphBuilderOrt::GetOperandName(uint64_t operand_id) {
   }
 }
 
-std::string GraphBuilderOrt::CreateInitializerAsRawData(
-    base::span<const uint32_t> shape,
-    base::span<const uint8_t> data,
-    OperandDataType data_type) {
+template <typename T>
+std::string GraphBuilderOrt::CreateInitializer(base::span<const uint32_t> shape,
+                                               base::span<const T> data,
+                                               OperandDataType data_type,
+                                               bool used_for_shape_inference) {
   std::string name = GetInsertedOperandName(next_operand_id_);
   OperandInfo operand_info{name, data_type, shape};
+  size_t byte_size = sizeof(T) * data.size();
 
-  model_builder_.AddInitializerAsRawData(name, operand_info.int64_shape, data,
-                                         operand_info.onnx_data_type);
+  if (byte_size < kMinExternalDataSize || used_for_shape_inference) {
+    model_builder_.AddInitializerAsRawData(
+        name, operand_info.int64_shape,
+        base::span(reinterpret_cast<const uint8_t*>(data.data()), byte_size),
+        operand_info.onnx_data_type);
+  } else {
+    model_builder_.AddInitializerAsExternalData(
+        name, operand_info.int64_shape,
+        base::span(reinterpret_cast<const uint8_t*>(data.data()), byte_size),
+        operand_info.onnx_data_type);
+  }
 
   CHECK(result_->id_to_operand_info
             .try_emplace(next_operand_id_, std::move(operand_info))
@@ -288,16 +302,24 @@ void GraphBuilderOrt::AddOutput(uint64_t output_id) {
             .second);
 }
 
-void GraphBuilderOrt::AddInitializerAsExternalData(uint64_t constant_id) {
+void GraphBuilderOrt::AddInitializer(uint64_t constant_id,
+                                     bool used_for_shape_inference) {
   const WebNNConstantOperand& operand = *constant_operands_.at(constant_id);
   std::string name = GetOperandName(constant_id);
 
   OperandInfo operand_info{name, operand.descriptor().data_type(),
                            operand.descriptor().shape()};
+  size_t byte_size = operand.ByteSpan().size();
 
-  model_builder_.AddInitializerAsExternalData(name, operand_info.int64_shape,
-                                              operand.ByteSpan(),
-                                              operand_info.onnx_data_type);
+  if (byte_size < kMinExternalDataSize || used_for_shape_inference) {
+    model_builder_.AddInitializerAsRawData(name, operand_info.int64_shape,
+                                           operand.ByteSpan(),
+                                           operand_info.onnx_data_type);
+  } else {
+    model_builder_.AddInitializerAsExternalData(name, operand_info.int64_shape,
+                                                operand.ByteSpan(),
+                                                operand_info.onnx_data_type);
+  }
 
   CHECK(result_->id_to_operand_info
             .try_emplace(constant_id, std::move(operand_info))
@@ -509,12 +531,9 @@ void GraphBuilderOrt::AddClampOperation(const mojom::Clamp& clamp) {
           << "[WebNN] Clamp only supports float32 and float16 data type.";
   }
 
-  // Verified that we can also use external data here.
-  // TODO(https://github.com/shiyi9801/chromium/issues/52): Determine whether to
-  // use raw data or external data, which one is better?
-  const std::string min_name = CreateInitializerAsRawData(
+  const std::string min_name = CreateInitializer<uint8_t>(
       /*shape=*/{}, min_value, input_data_type);
-  const std::string max_name = CreateInitializerAsRawData(
+  const std::string max_name = CreateInitializer<uint8_t>(
       /*shape=*/{}, max_value, input_data_type);
 
   std::array<const char*, 3> input_names = {input_name.c_str(),
@@ -590,11 +609,8 @@ void GraphBuilderOrt::AddExpandOperation(const mojom::Expand& expand) {
       output_shape, std::back_inserter(shape_values),
       [](uint32_t dim) { return static_cast<int64_t>(dim); });
   // Expand op needs parameter *shape* as raw data to do shape inference.
-  const std::string shape_name = CreateInitializerAsRawData(
-      shape_dims,
-      base::span(reinterpret_cast<const uint8_t*>(shape_values.data()),
-                 sizeof(int64_t) * shape_values.size()),
-      OperandDataType::kInt64);
+  const std::string shape_name = CreateInitializer<int64_t>(
+      shape_dims, shape_values, OperandDataType::kInt64, true);
 
   std::array<const char*, 2> input_names = {input_name.c_str(),
                                             shape_name.c_str()};
@@ -664,8 +680,7 @@ GraphBuilderOrt::AddInstanceNormalizationOperation(
   std::vector<uint32_t> constant_dims = {input_channel};
 
   std::string scale_name, bias_name;
-  // ONNX requires scale and bias inputs. And they must be uploaded as raw data,
-  // otherwise there will be runtime error.
+  // ONNX requires scale and bias inputs.
   if (instance_normalization.scale_operand_id) {
     scale_name =
         GetOperandName(instance_normalization.scale_operand_id.value());
@@ -676,19 +691,13 @@ GraphBuilderOrt::AddInstanceNormalizationOperation(
       case OperandDataType::kFloat16: {
         std::vector<uint16_t> scale_data_fp16 =
             ConvertFloat32ToFloat16(scale_data);
-        scale_name = CreateInitializerAsRawData(
-            constant_dims,
-            base::span(reinterpret_cast<const uint8_t*>(scale_data_fp16.data()),
-                       sizeof(uint16_t) * scale_data_fp16.size()),
-            input_data_type);
+        scale_name = CreateInitializer<uint16_t>(constant_dims, scale_data_fp16,
+                                                 input_data_type);
         break;
       }
       case OperandDataType::kFloat32: {
-        scale_name = CreateInitializerAsRawData(
-            constant_dims,
-            base::span(reinterpret_cast<const uint8_t*>(scale_data.data()),
-                       sizeof(float) * scale_data.size()),
-            input_data_type);
+        scale_name = CreateInitializer<float>(constant_dims, scale_data,
+                                              input_data_type);
         break;
       }
       default:
@@ -708,19 +717,13 @@ GraphBuilderOrt::AddInstanceNormalizationOperation(
       case OperandDataType::kFloat16: {
         std::vector<uint16_t> bias_data_fp16 =
             ConvertFloat32ToFloat16(bias_data);
-        bias_name = CreateInitializerAsRawData(
-            constant_dims,
-            base::span(reinterpret_cast<const uint8_t*>(bias_data_fp16.data()),
-                       sizeof(uint16_t) * bias_data_fp16.size()),
-            input_data_type);
+        bias_name = CreateInitializer<uint16_t>(constant_dims, bias_data_fp16,
+                                                input_data_type);
         break;
       }
       case OperandDataType::kFloat32: {
-        bias_name = CreateInitializerAsRawData(
-            constant_dims,
-            base::span(reinterpret_cast<const uint8_t*>(bias_data.data()),
-                       sizeof(float) * bias_data.size()),
-            input_data_type);
+        bias_name =
+            CreateInitializer<float>(constant_dims, bias_data, input_data_type);
         break;
       }
       default:
@@ -865,11 +868,9 @@ void GraphBuilderOrt::AddReduceOperation(const mojom::Reduce& reduce) {
     // axes is an operand with data type int64, not an attribute.
     std::vector<uint32_t> axes_dims = {
         base::checked_cast<uint32_t>(axes.size())};
-    axes_name = CreateInitializerAsRawData(
-        axes_dims,
-        base::span(reinterpret_cast<const uint8_t*>(axes.data()),
-                   sizeof(int64_t) * axes.size()),
-        OperandDataType::kInt64);
+    // Reduce op needs parameter *axes* as raw data to do shape inference.
+    axes_name = CreateInitializer<int64_t>(axes_dims, axes,
+                                           OperandDataType::kInt64, true);
     input_names.push_back(axes_name.c_str());
   }
 
@@ -911,11 +912,9 @@ void GraphBuilderOrt::AddReshapeOperation(const mojom::Reshape& reshape) {
   base::ranges::transform(
       output_shape, std::back_inserter(shape_values),
       [](uint32_t dim) { return static_cast<int64_t>(dim); });
-  const std::string shape_name = CreateInitializerAsRawData(
-      shape_dims,
-      base::span(reinterpret_cast<const uint8_t*>(shape_values.data()),
-                 sizeof(int64_t) * shape_values.size()),
-      OperandDataType::kInt64);
+  // Reshape op needs parameter *shape* as raw data to do shape inference.
+  const std::string shape_name = CreateInitializer<int64_t>(
+      shape_dims, shape_values, OperandDataType::kInt64, true);
 
   std::array<const char*, 2> input_names = {input_name.c_str(),
                                             shape_name.c_str()};
@@ -944,31 +943,22 @@ void GraphBuilderOrt::AddSliceOperation(const mojom::Slice& slice) {
   std::vector<uint32_t> starts_shape = {
       base::checked_cast<uint32_t>(beginnings.size())};
   // Slice op needs parameter *starts* as raw data to do shape inference.
-  const std::string starts_name = CreateInitializerAsRawData(
-      starts_shape,
-      base::span(reinterpret_cast<const uint8_t*>(beginnings.data()),
-                 sizeof(int64_t) * beginnings.size()),
-      OperandDataType::kInt64);
+  const std::string starts_name = CreateInitializer<int64_t>(
+      starts_shape, beginnings, OperandDataType::kInt64, true);
 
   // Ends is an operand with data type int64, not an attribute.
   std::vector<uint32_t> ends_shape = {
       base::checked_cast<uint32_t>(endings.size())};
   // Slice op needs parameter *ends* as raw data to do shape inference.
-  const std::string ends_name = CreateInitializerAsRawData(
-      ends_shape,
-      base::span(reinterpret_cast<const uint8_t*>(endings.data()),
-                 sizeof(int64_t) * endings.size()),
-      OperandDataType::kInt64);
+  const std::string ends_name = CreateInitializer<int64_t>(
+      ends_shape, endings, OperandDataType::kInt64, true);
 
   // Steps is an operand with data type int64, not an attribute.
   std::vector<uint32_t> steps_shape = {
       base::checked_cast<uint32_t>(strides.size())};
   // Slice op needs parameter *steps* as raw data to do shape inference.
-  const std::string steps_name = CreateInitializerAsRawData(
-      steps_shape,
-      base::span(reinterpret_cast<const uint8_t*>(strides.data()),
-                 sizeof(int64_t) * strides.size()),
-      OperandDataType::kInt64);
+  const std::string steps_name = CreateInitializer<int64_t>(
+      steps_shape, strides, OperandDataType::kInt64, true);
 
   // Axes is an optional input, if not provided, it is an empty string and will
   // be treated as [0, 1, …, len(starts) - 1]:
@@ -1064,7 +1054,7 @@ GraphBuilderOrt::BuildModel() {
 
   // Add initializers.
   for (const auto& [constant_id, _] : constant_operands_) {
-    AddInitializerAsExternalData(constant_id);
+    AddInitializer(constant_id);
   }
 
   // Add operations.

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -89,9 +89,6 @@ constexpr char kOpTypeWhere[] = "Where";
 
 // constexpr char kBuildGraphError[] = "Failed to build graph.";
 
-// Define the minimum size(in bytes) to use external data.
-constexpr size_t kMinExternalDataSize = 128;
-
 base::unexpected<mojom::ErrorPtr> NewNotSupportedError(std::string message) {
   return base::unexpected(mojom::Error::New(
       mojom::Error::Code::kNotSupportedError, std::move(message)));
@@ -247,23 +244,20 @@ std::string GraphBuilderOrt::GetOperandName(uint64_t operand_id) {
 template <typename T>
 std::string GraphBuilderOrt::CreateInitializer(base::span<const uint32_t> shape,
                                                base::span<const T> data,
-                                               OperandDataType data_type,
-                                               bool used_for_shape_inference) {
+                                               OperandDataType data_type) {
   std::string name = GetInsertedOperandName(next_operand_id_);
   OperandInfo operand_info{name, data_type, shape};
-  size_t byte_size = sizeof(T) * data.size();
-
-  if (byte_size < kMinExternalDataSize || used_for_shape_inference) {
-    model_builder_.AddInitializerAsRawData(
-        name, operand_info.int64_shape,
-        base::span(reinterpret_cast<const uint8_t*>(data.data()), byte_size),
-        operand_info.onnx_data_type);
+  base::span<const uint8_t> byte_span;
+  if constexpr (std::floating_point<T>) {
+    // Floating point types do not have unique object representations, but
+    // this code appears to be using a byte span to type-erase, which is fine.
+    byte_span = base::as_byte_span(base::allow_nonunique_obj, data);
   } else {
-    model_builder_.AddInitializerAsExternalData(
-        name, operand_info.int64_shape,
-        base::span(reinterpret_cast<const uint8_t*>(data.data()), byte_size),
-        operand_info.onnx_data_type);
+    byte_span = base::as_byte_span(data);
   }
+
+  model_builder_.AddInitializer(name, operand_info.int64_shape, byte_span,
+                                operand_info.onnx_data_type);
 
   CHECK(result_->id_to_operand_info
             .try_emplace(next_operand_id_, std::move(operand_info))
@@ -302,24 +296,15 @@ void GraphBuilderOrt::AddOutput(uint64_t output_id) {
             .second);
 }
 
-void GraphBuilderOrt::AddInitializer(uint64_t constant_id,
-                                     bool used_for_shape_inference) {
+void GraphBuilderOrt::AddInitializer(uint64_t constant_id) {
   const WebNNConstantOperand& operand = *constant_operands_.at(constant_id);
   std::string name = GetOperandName(constant_id);
 
   OperandInfo operand_info{name, operand.descriptor().data_type(),
                            operand.descriptor().shape()};
-  size_t byte_size = operand.ByteSpan().size();
-
-  if (byte_size < kMinExternalDataSize || used_for_shape_inference) {
-    model_builder_.AddInitializerAsRawData(name, operand_info.int64_shape,
-                                           operand.ByteSpan(),
-                                           operand_info.onnx_data_type);
-  } else {
-    model_builder_.AddInitializerAsExternalData(name, operand_info.int64_shape,
-                                                operand.ByteSpan(),
-                                                operand_info.onnx_data_type);
-  }
+  model_builder_.AddInitializer(name, operand_info.int64_shape,
+                                operand.ByteSpan(),
+                                operand_info.onnx_data_type);
 
   CHECK(result_->id_to_operand_info
             .try_emplace(constant_id, std::move(operand_info))
@@ -608,9 +593,8 @@ void GraphBuilderOrt::AddExpandOperation(const mojom::Expand& expand) {
   base::ranges::transform(
       output_shape, std::back_inserter(shape_values),
       [](uint32_t dim) { return static_cast<int64_t>(dim); });
-  // Expand op needs parameter *shape* as raw data to do shape inference.
   const std::string shape_name = CreateInitializer<int64_t>(
-      shape_dims, shape_values, OperandDataType::kInt64, true);
+      shape_dims, shape_values, OperandDataType::kInt64);
 
   std::array<const char*, 2> input_names = {input_name.c_str(),
                                             shape_name.c_str()};
@@ -868,9 +852,8 @@ void GraphBuilderOrt::AddReduceOperation(const mojom::Reduce& reduce) {
     // axes is an operand with data type int64, not an attribute.
     std::vector<uint32_t> axes_dims = {
         base::checked_cast<uint32_t>(axes.size())};
-    // Reduce op needs parameter *axes* as raw data to do shape inference.
-    axes_name = CreateInitializer<int64_t>(axes_dims, axes,
-                                           OperandDataType::kInt64, true);
+    axes_name =
+        CreateInitializer<int64_t>(axes_dims, axes, OperandDataType::kInt64);
     input_names.push_back(axes_name.c_str());
   }
 
@@ -912,9 +895,8 @@ void GraphBuilderOrt::AddReshapeOperation(const mojom::Reshape& reshape) {
   base::ranges::transform(
       output_shape, std::back_inserter(shape_values),
       [](uint32_t dim) { return static_cast<int64_t>(dim); });
-  // Reshape op needs parameter *shape* as raw data to do shape inference.
   const std::string shape_name = CreateInitializer<int64_t>(
-      shape_dims, shape_values, OperandDataType::kInt64, true);
+      shape_dims, shape_values, OperandDataType::kInt64);
 
   std::array<const char*, 2> input_names = {input_name.c_str(),
                                             shape_name.c_str()};
@@ -942,23 +924,20 @@ void GraphBuilderOrt::AddSliceOperation(const mojom::Slice& slice) {
   // Starts is an operand with data type int64, not an attribute.
   std::vector<uint32_t> starts_shape = {
       base::checked_cast<uint32_t>(beginnings.size())};
-  // Slice op needs parameter *starts* as raw data to do shape inference.
   const std::string starts_name = CreateInitializer<int64_t>(
-      starts_shape, beginnings, OperandDataType::kInt64, true);
+      starts_shape, beginnings, OperandDataType::kInt64);
 
   // Ends is an operand with data type int64, not an attribute.
   std::vector<uint32_t> ends_shape = {
       base::checked_cast<uint32_t>(endings.size())};
-  // Slice op needs parameter *ends* as raw data to do shape inference.
-  const std::string ends_name = CreateInitializer<int64_t>(
-      ends_shape, endings, OperandDataType::kInt64, true);
+  const std::string ends_name =
+      CreateInitializer<int64_t>(ends_shape, endings, OperandDataType::kInt64);
 
   // Steps is an operand with data type int64, not an attribute.
   std::vector<uint32_t> steps_shape = {
       base::checked_cast<uint32_t>(strides.size())};
-  // Slice op needs parameter *steps* as raw data to do shape inference.
-  const std::string steps_name = CreateInitializer<int64_t>(
-      steps_shape, strides, OperandDataType::kInt64, true);
+  const std::string steps_name =
+      CreateInitializer<int64_t>(steps_shape, strides, OperandDataType::kInt64);
 
   // Axes is an optional input, if not provided, it is an empty string and will
   // be treated as [0, 1, …, len(starts) - 1]:

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -94,29 +94,33 @@ class GraphBuilderOrt {
   const mojom::Operand& GetOperand(uint64_t operand_id);
   std::string GetOperandName(uint64_t operand_id);
 
-  // Some initializers must be uploaded to raw data, for example:
-  // 1. Reshape op needs parameter *shape* as raw data to do shape inference.
-  // 2. Reduce op needs parameter *axes* as raw data to do shape inference.
-  // 3. Expand op needs parameter *shape* as raw data to do shape inference.
-  // 4. Slice op needs parameter *starts*, *ends* and *steps* as raw data to do
-  // shape inference.
+  // Create a new initializer for the graph with the given shape, data and data
+  // type, return the name of the initializer.
   //
-  // See issue(https://github.com/shiyi9801/chromium/issues/52) for more
-  // details.
+  // Use the raw data when:
+  // 1. The byte size of the data is less than 128.
+  // 2. The initializer is used for shape inference.
+  // Otherwise, use external data.
   //
-  // Create a new initializer copied into graph.
-  std::string CreateInitializerAsRawData(base::span<const uint32_t> shape,
-                                         base::span<const uint8_t> data,
-                                         OperandDataType data_type);
+  // For example, some initializers must use raw data to do shape inference, and
+  // they are almost always smaller than 128 bytes:
+  // 1. Reshape: parameter *shape*.
+  // 2. Reduce: parameter *axes*.
+  // 3. Expand: parameter *shape*.
+  // 4. Slice: parameter *starts*, *ends* and *steps*.
+  template <typename T>
+  std::string CreateInitializer(base::span<const uint32_t> shape,
+                                base::span<const T> data,
+                                OperandDataType data_type,
+                                bool used_for_shape_inference = false);
 
   void AddInput(uint64_t input_id);
   void AddOutput(uint64_t output_id);
 
-  // TODO(https://github.com/shiyi9801/chromium/issues/52): Figure out whether
-  // to upload constants to external data or raw data in graph.
-  //
-  // Add initializer to external data.
-  void AddInitializerAsExternalData(uint64_t constant_id);
+  // Similar to the `CreateInitializer` above, add an initializer to the graph
+  // with the given constant from WebNN, return the name of the initializer.
+  void AddInitializer(uint64_t constant_id,
+                      bool used_for_shape_inference = false);
 
   template <typename T>
   void AddBinaryOperation(const T& operation, std::string op_type);

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -97,13 +97,17 @@ class GraphBuilderOrt {
   // Create a new initializer for the graph with the given shape, data and data
   // type, return the name of the initializer.
   //
-  // Use the raw data when:
+  // The guidelines recommends using raw data when:
   // 1. The byte size of the data is less than 128.
   // 2. The initializer is used for shape inference.
   // Otherwise, use external data.
   //
-  // For example, some initializers must use raw data to do shape inference, and
-  // they are almost always smaller than 128 bytes:
+  // Actually, 128 byte size would cover all initializers used for shape
+  // inference, because it could carry 16 x int64_t values and the existing
+  // WebNN maximum rank is 8, so whether to use raw data only depends on the
+  // data size.
+  //
+  // For example, some initializers will use raw data to do shape inference:
   // 1. Reshape: parameter *shape*.
   // 2. Reduce: parameter *axes*.
   // 3. Expand: parameter *shape*.
@@ -111,16 +115,14 @@ class GraphBuilderOrt {
   template <typename T>
   std::string CreateInitializer(base::span<const uint32_t> shape,
                                 base::span<const T> data,
-                                OperandDataType data_type,
-                                bool used_for_shape_inference = false);
+                                OperandDataType data_type);
 
   void AddInput(uint64_t input_id);
   void AddOutput(uint64_t output_id);
 
   // Similar to the `CreateInitializer` above, add an initializer to the graph
-  // with the given constant from WebNN, return the name of the initializer.
-  void AddInitializer(uint64_t constant_id,
-                      bool used_for_shape_inference = false);
+  // with the given constant from WebNN.
+  void AddInitializer(uint64_t constant_id);
 
   template <typename T>
   void AddBinaryOperation(const T& operation, std::string op_type);

--- a/services/webnn/ort/ort_model_builder.cc
+++ b/services/webnn/ort/ort_model_builder.cc
@@ -15,6 +15,9 @@ namespace {
 constexpr char kOrtDomainName[] = "";
 constexpr int32_t kOrtOpsetVersion = 21;
 
+// Define the minimum size(in bytes) to use external data.
+constexpr size_t kMinExternalDataSize = 128;
+
 }  // namespace
 
 namespace ort {
@@ -63,48 +66,38 @@ void OrtModelBuilder::AddOutput(std::string_view name,
   outputs_.push_back(CreateOrtValueInfo(name, shape, data_type));
 }
 
-void OrtModelBuilder::AddInitializerAsRawData(
-    std::string_view name,
-    base::span<const int64_t> shape,
-    base::span<const uint8_t> data,
-    ONNXTensorElementDataType data_type) {
+void OrtModelBuilder::AddInitializer(std::string_view name,
+                                     base::span<const int64_t> shape,
+                                     base::span<const uint8_t> data,
+                                     ONNXTensorElementDataType data_type) {
   ScopedOrtValuePtr initializer;
-  CHECK_STATUS(GetOrtApi()->CreateTensorAsOrtValue(
-      allocator_->allocator(), shape.data(), shape.size(), data_type,
-      initializer.GetAddressOf()));
+  bool data_is_external = data.size() >= kMinExternalDataSize;
+  if (data_is_external) {
+    auto weight = base::HeapArray<uint8_t>::CopiedFrom(data);
+    model_info_->external_data.push_back(std::move(weight));
+    // TODO(https://github.com/shiyi9801/chromium/issues/45): Use
+    // `CreateTensorWithDataAndDeleterAsOrtValue()`.
+    CHECK_STATUS(GetOrtApi()->CreateTensorWithDataAsOrtValue(
+        allocator_->memory_info(), model_info_->external_data.back().data(),
+        model_info_->external_data.back().size(), shape.data(), shape.size(),
+        data_type, initializer.GetAddressOf()));
+  } else {
+    CHECK_STATUS(GetOrtApi()->CreateTensorAsOrtValue(
+        allocator_->allocator(), shape.data(), shape.size(), data_type,
+        initializer.GetAddressOf()));
 
-  void* ort_tensor_raw_data = nullptr;
-  CHECK_STATUS(
-      GetOrtApi()->GetTensorMutableData(initializer, &ort_tensor_raw_data));
-  CHECK(ort_tensor_raw_data);
-  UNSAFE_BUFFERS(
-      base::span(static_cast<uint8_t*>(ort_tensor_raw_data), data.size()))
-      .copy_from(data);
+    void* ort_tensor_raw_data = nullptr;
+    CHECK_STATUS(
+        GetOrtApi()->GetTensorMutableData(initializer, &ort_tensor_raw_data));
+    CHECK(ort_tensor_raw_data);
+    UNSAFE_BUFFERS(
+        base::span(static_cast<uint8_t*>(ort_tensor_raw_data), data.size()))
+        .copy_from(data);
+  }
+
   // Graph will own the initializer.
   CHECK_STATUS(GetOrtModelBuilderApi()->AddInitializerToGraph(
-      graph_, name.data(), initializer.Release(),
-      /*data_is_external=*/false));
-}
-
-void OrtModelBuilder::AddInitializerAsExternalData(
-    std::string_view name,
-    base::span<const int64_t> shape,
-    base::span<const uint8_t> data,
-    ONNXTensorElementDataType data_type) {
-  auto weight = base::HeapArray<uint8_t>::CopiedFrom(data);
-  model_info_->external_data.push_back(std::move(weight));
-
-  ScopedOrtValuePtr initializer;
-  // TODO(https://github.com/shiyi9801/chromium/issues/45): Use
-  // `CreateTensorWithDataAndDeleterAsOrtValue()`.
-  CHECK_STATUS(GetOrtApi()->CreateTensorWithDataAsOrtValue(
-      allocator_->memory_info(), model_info_->external_data.back().data(),
-      model_info_->external_data.back().size(), shape.data(), shape.size(),
-      data_type, initializer.GetAddressOf()));
-  // Graph will own the initializer.
-  CHECK_STATUS(GetOrtModelBuilderApi()->AddInitializerToGraph(
-      graph_, name.data(), initializer.Release(),
-      /*data_is_external=*/true));
+      graph_, name.data(), initializer.Release(), data_is_external));
 }
 
 void OrtModelBuilder::CreateAttribute(ScopedOrtOpAttrPtr& attribute,

--- a/services/webnn/ort/ort_model_builder.h
+++ b/services/webnn/ort/ort_model_builder.h
@@ -52,15 +52,12 @@ class OrtModelBuilder final {
                  base::span<const int64_t> shape,
                  ONNXTensorElementDataType data_type);
 
-  void AddInitializerAsRawData(std::string_view name,
-                               base::span<const int64_t> shape,
-                               base::span<const uint8_t> data,
-                               ONNXTensorElementDataType data_type);
-
-  void AddInitializerAsExternalData(std::string_view name,
-                                    base::span<const int64_t> shape,
-                                    base::span<const uint8_t> data,
-                                    ONNXTensorElementDataType data_type);
+  // Add an initializer to the graph. It will use raw data if byte size
+  // of the data is less than 128.
+  void AddInitializer(std::string_view name,
+                      base::span<const int64_t> shape,
+                      base::span<const uint8_t> data,
+                      ONNXTensorElementDataType data_type);
 
   using OrtOpAttrData = absl::variant<int64_t,
                                       float,


### PR DESCRIPTION
1. Rafactor codes: `CreateInitializerAsRawData` to template `CreateInitializer` with `base::span<const T> data`;
rename `AddInitializerAsExternalData` as `AddInitializer`.
2. Create/Add initializers with the raw data when:
  a. The byte size of the data is less than 128.
  b. The initializer is used for shape inference.
Otherwise, use external data.

PTAL, thanks! 
