### PR TITLE
Enable OpenVINO EP

### DIFF
--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -180,12 +180,14 @@ const GraphBuilderOrt::OperandInfo& GraphBuilderOrt::Result::GetOperandInfo(
 // static
 base::expected<std::unique_ptr<GraphBuilderOrt::Result>, mojom::ErrorPtr>
 GraphBuilderOrt::CreateAndBuild(
+    mojom::CreateContextOptions::Device device_type,
     const mojom::GraphInfo& graph_info,
     ContextProperties context_properties,
     base::flat_map<uint64_t, std::unique_ptr<WebNNConstantOperand>>
         constant_operands,
     scoped_refptr<AllocatorOrt> allocator) {
-  GraphBuilderOrt graph_builder(graph_info, std::move(context_properties),
+  GraphBuilderOrt graph_builder(device_type, graph_info,
+                                std::move(context_properties),
                                 std::move(constant_operands), allocator);
 
   RETURN_IF_ERROR(graph_builder.BuildModel());
@@ -193,12 +195,14 @@ GraphBuilderOrt::CreateAndBuild(
 }
 
 GraphBuilderOrt::GraphBuilderOrt(
+    mojom::CreateContextOptions::Device device_type,
     const mojom::GraphInfo& graph_info,
     ContextProperties context_properties,
     base::flat_map<uint64_t, std::unique_ptr<WebNNConstantOperand>>
         constant_operands,
     scoped_refptr<AllocatorOrt> allocator)
-    : graph_info_(graph_info),
+    : device_type_(device_type),
+      graph_info_(graph_info),
       constant_operands_(std::move(constant_operands)),
       context_properties_(std::move(context_properties)),
       model_builder_(OrtModelBuilder(std::move(allocator))),
@@ -256,8 +260,15 @@ std::string GraphBuilderOrt::CreateInitializer(base::span<const uint32_t> shape,
     byte_span = base::as_byte_span(data);
   }
 
-  model_builder_.AddInitializer(name, operand_info.int64_shape, byte_span,
-                                operand_info.onnx_data_type);
+  // TODO(https://github.com/shiyi9801/chromium/issues/70): Remove this
+  // workaround for OpenVINO EP once the invalid external data issue is fixed.
+  if (device_type_ == mojom::CreateContextOptions::Device::kCpu) {
+    model_builder_.AddInitializer(name, operand_info.int64_shape, byte_span,
+                                  operand_info.onnx_data_type);
+  } else {
+    model_builder_.AddInitializerAsRawData(
+        name, operand_info.int64_shape, byte_span, operand_info.onnx_data_type);
+  }
 
   CHECK(result_->id_to_operand_info
             .try_emplace(next_operand_id_, std::move(operand_info))
@@ -302,9 +313,18 @@ void GraphBuilderOrt::AddInitializer(uint64_t constant_id) {
 
   OperandInfo operand_info{name, operand.descriptor().data_type(),
                            operand.descriptor().shape()};
-  model_builder_.AddInitializer(name, operand_info.int64_shape,
-                                operand.ByteSpan(),
-                                operand_info.onnx_data_type);
+
+  // TODO(https://github.com/shiyi9801/chromium/issues/70): Remove this
+  // workaround for OpenVINO EP once the invalid external data issue is fixed.
+  if (device_type_ == mojom::CreateContextOptions::Device::kCpu) {
+    model_builder_.AddInitializer(name, operand_info.int64_shape,
+                                  operand.ByteSpan(),
+                                  operand_info.onnx_data_type);
+  } else {
+    model_builder_.AddInitializerAsRawData(name, operand_info.int64_shape,
+                                           operand.ByteSpan(),
+                                           operand_info.onnx_data_type);
+  }
 
   CHECK(result_->id_to_operand_info
             .try_emplace(constant_id, std::move(operand_info))

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -72,7 +72,8 @@ class GraphBuilderOrt {
   //
   // Returns unexpected if it fails.
   [[nodiscard]] static base::expected<std::unique_ptr<Result>, mojom::ErrorPtr>
-  CreateAndBuild(const mojom::GraphInfo& graph_info,
+  CreateAndBuild(mojom::CreateContextOptions::Device device_type,
+                 const mojom::GraphInfo& graph_info,
                  ContextProperties context_properties,
                  base::flat_map<uint64_t, std::unique_ptr<WebNNConstantOperand>>
                      constant_operands,
@@ -85,6 +86,7 @@ class GraphBuilderOrt {
 
  private:
   GraphBuilderOrt(
+      mojom::CreateContextOptions::Device device_type,
       const mojom::GraphInfo& graph_info,
       ContextProperties context_properties,
       base::flat_map<uint64_t, std::unique_ptr<WebNNConstantOperand>>
@@ -156,6 +158,8 @@ class GraphBuilderOrt {
 
   // Used for inserting new operands into graph.
   uint64_t next_operand_id_ = 0;
+
+  mojom::CreateContextOptions::Device device_type_;
 
   // A reference to the WebNN compute graph that `this` instance is converting
   // to ONNX model. The creator of `this` must ensure the GraphInfo reference

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -110,8 +110,10 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
   CHECK_STATUS(ort_api->SetSessionGraphOptimizationLevel(
       session_options, GraphOptimizationLevel::ORT_ENABLE_BASIC));
 
-  // OpenVINO backend doesn't support dumping optimized model since it contains
-  // compiled nodes.
+  // TODO(https://github.com/shiyi9801/chromium/issues/72): Investigate if there
+  // is another way to dump the model for OpenVINO EP.
+  // OpenVINO EP doesn't support dumping the optimized model since it contains
+  // compiled nodes which cannnot be serialized.
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
           switches::kWebNNOrtDumpModel) &&
       context_options->device == mojom::CreateContextOptions::Device::kCpu) {

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -110,8 +110,11 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
   CHECK_STATUS(ort_api->SetSessionGraphOptimizationLevel(
       session_options, GraphOptimizationLevel::ORT_ENABLE_BASIC));
 
+  // OpenVINO backend doesn't support dumping optimized model since it contains
+  // compiled nodes.
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kWebNNOrtDumpModel)) {
+          switches::kWebNNOrtDumpModel) &&
+      context_options->device == mojom::CreateContextOptions::Device::kCpu) {
     static uint64_t dump_count = 0;
     base::FilePath dump_directory =
         base::CommandLine::ForCurrentProcess()->GetSwitchValuePath(
@@ -126,8 +129,34 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
     // supports it.
   }
 
-  // TODO(https://github.com/shiyi9801/chromium/issues/46): Append OpenVINO EP
-  // for GPU and NPU devices.
+  // Select the execution provider.
+  switch (context_options->device) {
+    case mojom::CreateContextOptions::Device::kCpu: {
+      // TODO: Investigate how to apply layout optimizations (ORT_ENABLE_ALL):
+      // https://onnxruntime.ai/docs/performance/model-optimizations/graph-optimizations.html#layout-optimizations
+      CHECK_STATUS(ort_api->SetSessionGraphOptimizationLevel(
+          session_options, GraphOptimizationLevel::ORT_ENABLE_BASIC));
+      break;
+    }
+    case mojom::CreateContextOptions::Device::kGpu:
+    case mojom::CreateContextOptions::Device::kNpu: {
+      // It is recommended to disable the graph optimization for OpenVINO backend.
+      // https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#other-configuration-settings
+      CHECK_STATUS(ort_api->SetSessionGraphOptimizationLevel(
+          session_options, GraphOptimizationLevel::ORT_DISABLE_ALL));
+
+      std::string device_type =
+          context_options->device == mojom::CreateContextOptions::Device::kGpu
+              ? "GPU"
+              : "NPU";
+      OrtOpenVINOProviderOptions openvino_options;
+      openvino_options.device_type = device_type.c_str();
+
+      CHECK_STATUS(ort_api->SessionOptionsAppendExecutionProvider_OpenVINO(
+          session_options, &openvino_options));
+      break;
+    }
+  }
 
   OrtSession* session;
   const OrtEnv* env = allocator->env();
@@ -143,7 +172,7 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
                                               "Failed to create ORT session."));
   }
 
-  LOG(ERROR) << "Running on ORT=============";
+  LOG(ERROR) << "========= Running on ORT =============";
 
   return base::WrapUnique(new GraphImplOrt::Session(
       session, std::move(result->model_info->external_data)));

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -137,7 +137,8 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
   // Select the execution provider.
   switch (device_type) {
     case mojom::CreateContextOptions::Device::kCpu: {
-      // TODO: Investigate how to apply layout optimizations (ORT_ENABLE_ALL):
+      // TODO(https://github.com/shiyi9801/chromium/issues/58): Investigate how
+      // to apply layout optimizations (ORT_ENABLE_ALL).
       // https://onnxruntime.ai/docs/performance/model-optimizations/graph-optimizations.html#layout-optimizations
       CHECK_STATUS(ort_api->SetSessionGraphOptimizationLevel(
           session_options, GraphOptimizationLevel::ORT_ENABLE_BASIC));
@@ -157,8 +158,8 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
       OrtOpenVINOProviderOptions openvino_options;
       openvino_options.device_type = openvino_device_type.c_str();
 
-      // TODO: Fail early when creating the context if the OpenVINO EP is not
-      // supported.
+      // TODO(https://github.com/shiyi9801/chromium/issues/74): Fail early when
+      // creating the context if the OpenVINO EP is not supported.
       OrtStatus* append_openvino_status =
           ort_api->SessionOptionsAppendExecutionProvider_OpenVINO(
               session_options, &openvino_options);

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -96,9 +96,12 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
     base::flat_map<uint64_t, std::unique_ptr<WebNNConstantOperand>>
         constant_operands,
     scoped_refptr<AllocatorOrt> allocator) {
+  const mojom::CreateContextOptions::Device device_type =
+      context_options->device;
+
   ASSIGN_OR_RETURN(std::unique_ptr<GraphBuilderOrt::Result> result,
                    GraphBuilderOrt::CreateAndBuild(
-                       *graph_info, std::move(context_properties),
+                       device_type, *graph_info, std::move(context_properties),
                        std::move(constant_operands), allocator));
 
   OrtSessionOptions* session_options;
@@ -116,7 +119,7 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
   // compiled nodes which cannnot be serialized.
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
           switches::kWebNNOrtDumpModel) &&
-      context_options->device == mojom::CreateContextOptions::Device::kCpu) {
+      device_type == mojom::CreateContextOptions::Device::kCpu) {
     static uint64_t dump_count = 0;
     base::FilePath dump_directory =
         base::CommandLine::ForCurrentProcess()->GetSwitchValuePath(
@@ -132,7 +135,7 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
   }
 
   // Select the execution provider.
-  switch (context_options->device) {
+  switch (device_type) {
     case mojom::CreateContextOptions::Device::kCpu: {
       // TODO: Investigate how to apply layout optimizations (ORT_ENABLE_ALL):
       // https://onnxruntime.ai/docs/performance/model-optimizations/graph-optimizations.html#layout-optimizations
@@ -142,20 +145,31 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
     }
     case mojom::CreateContextOptions::Device::kGpu:
     case mojom::CreateContextOptions::Device::kNpu: {
-      // It is recommended to disable the graph optimization for OpenVINO backend.
+      // It is recommended to disable the graph optimization for OpenVINO
+      // backend.
       // https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#other-configuration-settings
       CHECK_STATUS(ort_api->SetSessionGraphOptimizationLevel(
           session_options, GraphOptimizationLevel::ORT_DISABLE_ALL));
 
-      std::string device_type =
-          context_options->device == mojom::CreateContextOptions::Device::kGpu
-              ? "GPU"
-              : "NPU";
+      std::string openvino_device_type =
+          device_type == mojom::CreateContextOptions::Device::kGpu ? "GPU"
+                                                                   : "NPU";
       OrtOpenVINOProviderOptions openvino_options;
-      openvino_options.device_type = device_type.c_str();
+      openvino_options.device_type = openvino_device_type.c_str();
 
-      CHECK_STATUS(ort_api->SessionOptionsAppendExecutionProvider_OpenVINO(
-          session_options, &openvino_options));
+      // TODO: Fail early when creating the context if the OpenVINO EP is not
+      // supported.
+      OrtStatus* append_openvino_status =
+          ort_api->SessionOptionsAppendExecutionProvider_OpenVINO(
+              session_options, &openvino_options);
+      if (append_openvino_status != NULL) {
+        std::string_view msg = ort_api->GetErrorMessage(append_openvino_status);
+        LOG(ERROR) << "[WebNN] Ort Status: " << msg;
+        ort_api->ReleaseStatus(append_openvino_status);
+        return base::unexpected(
+            mojom::Error::New(mojom::Error::Code::kUnknownError,
+                              "OnnxRuntime OpenVINO EP is not supported."));
+      }
       break;
     }
   }
@@ -167,9 +181,9 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
   ort_api->ReleaseSessionOptions(session_options);
 
   if (status != NULL) {
-    std::string msg = ort_api->GetErrorMessage(status);
+    std::string_view msg = ort_api->GetErrorMessage(status);
+    LOG(ERROR) << "[WebNN] Ort Status: " << msg;
     ort_api->ReleaseStatus(status);
-    LOG(ERROR) << "[WebNN] Ort Status " << msg;
     return base::unexpected(mojom::Error::New(mojom::Error::Code::kUnknownError,
                                               "Failed to create ORT session."));
   }

--- a/services/webnn/ort/ort_model_builder.cc
+++ b/services/webnn/ort/ort_model_builder.cc
@@ -70,34 +70,57 @@ void OrtModelBuilder::AddInitializer(std::string_view name,
                                      base::span<const int64_t> shape,
                                      base::span<const uint8_t> data,
                                      ONNXTensorElementDataType data_type) {
-  ScopedOrtValuePtr initializer;
   bool data_is_external = data.size() >= kMinExternalDataSize;
   if (data_is_external) {
-    auto weight = base::HeapArray<uint8_t>::CopiedFrom(data);
-    model_info_->external_data.push_back(std::move(weight));
-    // TODO(https://github.com/shiyi9801/chromium/issues/45): Use
-    // `CreateTensorWithDataAndDeleterAsOrtValue()`.
-    CHECK_STATUS(GetOrtApi()->CreateTensorWithDataAsOrtValue(
-        allocator_->memory_info(), model_info_->external_data.back().data(),
-        model_info_->external_data.back().size(), shape.data(), shape.size(),
-        data_type, initializer.GetAddressOf()));
+    AddInitializerAsExternalData(name, shape, data, data_type);
   } else {
-    CHECK_STATUS(GetOrtApi()->CreateTensorAsOrtValue(
-        allocator_->allocator(), shape.data(), shape.size(), data_type,
-        initializer.GetAddressOf()));
-
-    void* ort_tensor_raw_data = nullptr;
-    CHECK_STATUS(
-        GetOrtApi()->GetTensorMutableData(initializer, &ort_tensor_raw_data));
-    CHECK(ort_tensor_raw_data);
-    UNSAFE_BUFFERS(
-        base::span(static_cast<uint8_t*>(ort_tensor_raw_data), data.size()))
-        .copy_from(data);
+    AddInitializerAsRawData(name, shape, data, data_type);
   }
+}
+
+void OrtModelBuilder::AddInitializerAsRawData(
+    std::string_view name,
+    base::span<const int64_t> shape,
+    base::span<const uint8_t> data,
+    ONNXTensorElementDataType data_type) {
+  ScopedOrtValuePtr initializer;
+
+  CHECK_STATUS(GetOrtApi()->CreateTensorAsOrtValue(
+      allocator_->allocator(), shape.data(), shape.size(), data_type,
+      initializer.GetAddressOf()));
+
+  void* ort_tensor_raw_data = nullptr;
+  CHECK_STATUS(
+      GetOrtApi()->GetTensorMutableData(initializer, &ort_tensor_raw_data));
+  CHECK(ort_tensor_raw_data);
+  UNSAFE_BUFFERS(
+      base::span(static_cast<uint8_t*>(ort_tensor_raw_data), data.size()))
+      .copy_from(data);
 
   // Graph will own the initializer.
   CHECK_STATUS(GetOrtModelBuilderApi()->AddInitializerToGraph(
-      graph_, name.data(), initializer.Release(), data_is_external));
+      graph_, name.data(), initializer.Release(), /*data_is_external=*/false));
+}
+
+void OrtModelBuilder::AddInitializerAsExternalData(
+    std::string_view name,
+    base::span<const int64_t> shape,
+    base::span<const uint8_t> data,
+    ONNXTensorElementDataType data_type) {
+  ScopedOrtValuePtr initializer;
+
+  auto weight = base::HeapArray<uint8_t>::CopiedFrom(data);
+  model_info_->external_data.push_back(std::move(weight));
+  // TODO(https://github.com/shiyi9801/chromium/issues/45): Use
+  // `CreateTensorWithDataAndDeleterAsOrtValue()`.
+  CHECK_STATUS(GetOrtApi()->CreateTensorWithDataAsOrtValue(
+      allocator_->memory_info(), model_info_->external_data.back().data(),
+      model_info_->external_data.back().size(), shape.data(), shape.size(),
+      data_type, initializer.GetAddressOf()));
+
+  // Graph will own the initializer.
+  CHECK_STATUS(GetOrtModelBuilderApi()->AddInitializerToGraph(
+      graph_, name.data(), initializer.Release(), /*data_is_external=*/true));
 }
 
 void OrtModelBuilder::CreateAttribute(ScopedOrtOpAttrPtr& attribute,

--- a/services/webnn/ort/ort_model_builder.h
+++ b/services/webnn/ort/ort_model_builder.h
@@ -59,6 +59,16 @@ class OrtModelBuilder final {
                       base::span<const uint8_t> data,
                       ONNXTensorElementDataType data_type);
 
+  void AddInitializerAsRawData(std::string_view name,
+                               base::span<const int64_t> shape,
+                               base::span<const uint8_t> data,
+                               ONNXTensorElementDataType data_type);
+
+  void AddInitializerAsExternalData(std::string_view name,
+                                    base::span<const int64_t> shape,
+                                    base::span<const uint8_t> data,
+                                    ONNXTensorElementDataType data_type);
+
   using OrtOpAttrData = absl::variant<int64_t,
                                       float,
                                       std::string_view,


### PR DESCRIPTION
Due to the [invalid external data issue for OpenVINO EP](https://github.com/shiyi9801/chromium/issues/70), this PR adds a workaround that the initializers are all uploaded as graph raw data when the OpenVINO EP is enabled.

To test OpenVINO EP, you should

1. put the onnxruntime+openvino dlls under your Chromium build repository
2. start the Chromium with an extra --no-sandbox flag so ORT can load the openvino dlls
3. set the context deviceType to `gpu` or `npu` 