### PR TITLE
Introduce `--webnn-ort-use-openvino` switch

### DIFF
--- a/content/browser/gpu/gpu_process_host.cc
+++ b/content/browser/gpu/gpu_process_host.cc
@@ -329,6 +329,7 @@ static const char* const kSwitchNames[] = {
 #if BUILDFLAG(WEBNN_USE_ORT)
     switches::kWebNNUseOrt,
     switches::kWebNNOrtDumpModel,
+    switches::kWebNNOrtUseOpenvino,
 #endif
 };
 

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -6,6 +6,7 @@
 
 #include <numeric>
 
+#include "base/command_line.h"
 #include "base/logging.h"
 #include "base/notreached.h"
 #include "base/strings/strcat.h"
@@ -17,6 +18,7 @@
 #include "services/webnn/public/cpp/graph_validation_utils.h"
 #include "services/webnn/public/cpp/supported_data_types.h"
 #include "services/webnn/webnn_constant_operand.h"
+#include "services/webnn/webnn_switches.h"
 #include "third_party/fp16/src/include/fp16.h"
 
 namespace webnn {
@@ -185,14 +187,12 @@ const GraphBuilderOrt::OperandInfo& GraphBuilderOrt::Result::GetOperandInfo(
 // static
 base::expected<std::unique_ptr<GraphBuilderOrt::Result>, mojom::ErrorPtr>
 GraphBuilderOrt::CreateAndBuild(
-    mojom::CreateContextOptions::Device device_type,
     const mojom::GraphInfo& graph_info,
     ContextProperties context_properties,
     base::flat_map<uint64_t, std::unique_ptr<WebNNConstantOperand>>
         constant_operands,
     scoped_refptr<AllocatorOrt> allocator) {
-  GraphBuilderOrt graph_builder(device_type, graph_info,
-                                std::move(context_properties),
+  GraphBuilderOrt graph_builder(graph_info, std::move(context_properties),
                                 std::move(constant_operands), allocator);
 
   RETURN_IF_ERROR(graph_builder.BuildModel());
@@ -200,14 +200,12 @@ GraphBuilderOrt::CreateAndBuild(
 }
 
 GraphBuilderOrt::GraphBuilderOrt(
-    mojom::CreateContextOptions::Device device_type,
     const mojom::GraphInfo& graph_info,
     ContextProperties context_properties,
     base::flat_map<uint64_t, std::unique_ptr<WebNNConstantOperand>>
         constant_operands,
     scoped_refptr<AllocatorOrt> allocator)
-    : device_type_(device_type),
-      graph_info_(graph_info),
+    : graph_info_(graph_info),
       constant_operands_(std::move(constant_operands)),
       context_properties_(std::move(context_properties)),
       model_builder_(OrtModelBuilder(std::move(allocator))),
@@ -267,7 +265,8 @@ std::string GraphBuilderOrt::CreateInitializer(base::span<const uint32_t> shape,
 
   // TODO(https://github.com/shiyi9801/chromium/issues/70): Remove this
   // workaround for OpenVINO EP once the invalid external data issue is fixed.
-  if (device_type_ == mojom::CreateContextOptions::Device::kCpu) {
+  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kWebNNOrtUseOpenvino)) {
     model_builder_.AddInitializer(name, operand_info.int64_shape, byte_span,
                                   operand_info.onnx_data_type);
   } else {
@@ -321,7 +320,8 @@ void GraphBuilderOrt::AddInitializer(uint64_t constant_id) {
 
   // TODO(https://github.com/shiyi9801/chromium/issues/70): Remove this
   // workaround for OpenVINO EP once the invalid external data issue is fixed.
-  if (device_type_ == mojom::CreateContextOptions::Device::kCpu) {
+  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kWebNNOrtUseOpenvino)) {
     model_builder_.AddInitializer(name, operand_info.int64_shape,
                                   operand.ByteSpan(),
                                   operand_info.onnx_data_type);

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -72,8 +72,7 @@ class GraphBuilderOrt {
   //
   // Returns unexpected if it fails.
   [[nodiscard]] static base::expected<std::unique_ptr<Result>, mojom::ErrorPtr>
-  CreateAndBuild(mojom::CreateContextOptions::Device device_type,
-                 const mojom::GraphInfo& graph_info,
+  CreateAndBuild(const mojom::GraphInfo& graph_info,
                  ContextProperties context_properties,
                  base::flat_map<uint64_t, std::unique_ptr<WebNNConstantOperand>>
                      constant_operands,
@@ -86,7 +85,6 @@ class GraphBuilderOrt {
 
  private:
   GraphBuilderOrt(
-      mojom::CreateContextOptions::Device device_type,
       const mojom::GraphInfo& graph_info,
       ContextProperties context_properties,
       base::flat_map<uint64_t, std::unique_ptr<WebNNConstantOperand>>
@@ -165,8 +163,6 @@ class GraphBuilderOrt {
 
   // Used for inserting new operands into graph.
   uint64_t next_operand_id_ = 0;
-
-  mojom::CreateContextOptions::Device device_type_;
 
   // A reference to the WebNN compute graph that `this` instance is converting
   // to ONNX model. The creator of `this` must ensure the GraphInfo reference

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -101,7 +101,7 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
 
   ASSIGN_OR_RETURN(std::unique_ptr<GraphBuilderOrt::Result> result,
                    GraphBuilderOrt::CreateAndBuild(
-                       device_type, *graph_info, std::move(context_properties),
+                       *graph_info, std::move(context_properties),
                        std::move(constant_operands), allocator));
 
   OrtSessionOptions* session_options;
@@ -119,7 +119,8 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
   // compiled nodes which cannnot be serialized.
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
           switches::kWebNNOrtDumpModel) &&
-      device_type == mojom::CreateContextOptions::Device::kCpu) {
+      !base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kWebNNOrtUseOpenvino)) {
     static uint64_t dump_count = 0;
     base::FilePath dump_directory =
         base::CommandLine::ForCurrentProcess()->GetSwitchValuePath(
@@ -134,45 +135,54 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
     // supports it.
   }
 
-  // Select the execution provider.
-  switch (device_type) {
-    case mojom::CreateContextOptions::Device::kCpu: {
-      // TODO(https://github.com/shiyi9801/chromium/issues/58): Investigate how
-      // to apply layout optimizations (ORT_ENABLE_ALL).
-      // https://onnxruntime.ai/docs/performance/model-optimizations/graph-optimizations.html#layout-optimizations
-      CHECK_STATUS(ort_api->SetSessionGraphOptimizationLevel(
-          session_options, GraphOptimizationLevel::ORT_ENABLE_BASIC));
-      break;
-    }
-    case mojom::CreateContextOptions::Device::kGpu:
-    case mojom::CreateContextOptions::Device::kNpu: {
-      // It is recommended to disable the graph optimization for OpenVINO
-      // backend.
-      // https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#other-configuration-settings
-      CHECK_STATUS(ort_api->SetSessionGraphOptimizationLevel(
-          session_options, GraphOptimizationLevel::ORT_DISABLE_ALL));
-
-      std::string openvino_device_type =
-          device_type == mojom::CreateContextOptions::Device::kGpu ? "GPU"
-                                                                   : "NPU";
-      OrtOpenVINOProviderOptions openvino_options;
-      openvino_options.device_type = openvino_device_type.c_str();
-
-      // TODO(https://github.com/shiyi9801/chromium/issues/74): Fail early when
-      // creating the context if the OpenVINO EP is not supported.
-      OrtStatus* append_openvino_status =
-          ort_api->SessionOptionsAppendExecutionProvider_OpenVINO(
-              session_options, &openvino_options);
-      if (append_openvino_status != NULL) {
-        std::string_view msg = ort_api->GetErrorMessage(append_openvino_status);
-        LOG(ERROR) << "[WebNN] Ort Status: " << msg;
-        ort_api->ReleaseStatus(append_openvino_status);
-        return base::unexpected(
-            mojom::Error::New(mojom::Error::Code::kUnknownError,
-                              "OnnxRuntime OpenVINO EP is not supported."));
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kWebNNOrtUseOpenvino)) {
+    std::string openvino_device_type;
+    switch (device_type) {
+      case mojom::CreateContextOptions::Device::kCpu: {
+        openvino_device_type = "CPU";
+        break;
       }
-      break;
+      case mojom::CreateContextOptions::Device::kGpu: {
+        openvino_device_type = "GPU";
+        break;
+      }
+      case mojom::CreateContextOptions::Device::kNpu: {
+        openvino_device_type = "NPU";
+        break;
+      }
     }
+
+    // It is recommended to disable the graph optimization for OpenVINO
+    // backend.
+    // https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#other-configuration-settings
+    CHECK_STATUS(ort_api->SetSessionGraphOptimizationLevel(
+        session_options, GraphOptimizationLevel::ORT_DISABLE_ALL));
+
+    OrtOpenVINOProviderOptions openvino_options;
+    openvino_options.device_type = openvino_device_type.c_str();
+
+    // TODO(https://github.com/shiyi9801/chromium/issues/74): Fail early when
+    // creating the context if the OpenVINO EP is not supported.
+    OrtStatus* append_openvino_status =
+        ort_api->SessionOptionsAppendExecutionProvider_OpenVINO(
+            session_options, &openvino_options);
+    if (append_openvino_status != NULL) {
+      std::string_view msg = ort_api->GetErrorMessage(append_openvino_status);
+      LOG(ERROR) << "[WebNN] Ort Status: " << msg;
+      ort_api->ReleaseStatus(append_openvino_status);
+      return base::unexpected(
+          mojom::Error::New(mojom::Error::Code::kUnknownError,
+                            "OnnxRuntime OpenVINO EP is not supported."));
+    }
+  } else {
+    // Use CPU EP by default.
+    //
+    // TODO(https://github.com/shiyi9801/chromium/issues/58): Investigate how
+    // to apply layout optimizations (ORT_ENABLE_ALL).
+    // https://onnxruntime.ai/docs/performance/model-optimizations/graph-optimizations.html#layout-optimizations
+    CHECK_STATUS(ort_api->SetSessionGraphOptimizationLevel(
+        session_options, GraphOptimizationLevel::ORT_ENABLE_BASIC));
   }
 
   OrtSession* session;

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -34,6 +34,10 @@ inline constexpr char kWebNNUseOrt[] = "webnn-use-ort";
 // GPU process sandbox or --no-sandbox must be used.
 // Usage: --no-sandbox --webnn-ort-dump-model=./OnnxModels
 inline constexpr char kWebNNOrtDumpModel[] = "webnn-ort-dump-model";
+
+// Use OpenVINO EP of ONNX Runtime, WebNN device type will map OpenVINO device
+// type.
+inline constexpr char kWebNNOrtUseOpenvino[] = "webnn-ort-use-openvino";
 #endif  // BUILDFLAG(WEBNN_USE_ORT)
 
 }  // namespace switches


### PR DESCRIPTION
When `--webnn-ort-use-openvino` switch is used, OpenVINO EP will be used for all WebNN contexts. WebNN device type will map to OpenVINO EP device type.

With this change, developers (like me) can test OpenVINO EP on CPU. (My dev machine doesn't have Intel GPU or NPU).

Usage:
 1. Build OpenVINO EP by following: https://onnxruntime.ai/docs/build/eps.html#openvino 
     **Note**: Please use OpenVINO version >= 2024.4 (tested on 2024.6)
 3. Copy the following DLLs into Chromium build folder or version folder
```
onnxruntime.dll
onnxruntime_providers_shared.dll
onnxruntime_providers_openvino.dll
```
 4. Ensure OpenVINO environment variables are set, i.e.
```
"C:\Program Files (x86)\Intel\openvino_2024\setupvars.bat"
```
 5. Need to append --no-sandbox to load nessceary DLLs into GPU process, i.e.
```
chrome.exe --webnn-use-ort --use-redist-ort --webnn-ort-use-openvino --no-sandbox
```