### PR TITLE
Rename the operands to "label_id" to ensure the names are unique

### DIFF
--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -103,6 +103,9 @@ constexpr char kOpTypeTranspose[] = "Transpose";
 constexpr char kOpTypeTriangular[] = "Trilu";
 constexpr char kOpTypeWhere[] = "Where";
 
+constexpr char kInserted[] = "Inserted";
+constexpr char kUnderscore[] = "_";
+
 base::unexpected<mojom::ErrorPtr> NewNotSupportedError(std::string message) {
   return base::unexpected(mojom::Error::New(
       mojom::Error::Code::kNotSupportedError, std::move(message)));
@@ -179,6 +182,10 @@ struct TensorTypeMap<int64_t> {
 
 }  // namespace
 
+std::string GetOperandName(std::string_view label, uint64_t id) {
+  return base::JoinString({label, base::NumberToString(id)}, kUnderscore);
+}
+
 // static
 base::expected<std::unique_ptr<OrtModelBuilder::ModelInfo>, mojom::ErrorPtr>
 GraphBuilderOrt::CreateAndBuild(
@@ -212,40 +219,20 @@ const mojom::Operand& GraphBuilderOrt::GetOperand(uint64_t operand_id) {
   return *graph_info_->id_to_operand_map.at(operand_id);
 }
 
-// TODO(https://github.com/shiyi9801/chromium/issues/63): Make name generation
-// more robust.
 std::string GraphBuilderOrt::GetOperandNameById(uint64_t operand_id) {
   const mojom::Operand& operand = GetOperand(operand_id);
-  switch (operand.kind) {
-    case mojom::Operand::Kind::kInput: {
-      CHECK(operand.name.has_value());
-      // Add a prefix to avoid possible name collision.
-      return operand.name.value();
-      // return base::JoinString({"input", operand.name.value()}, "_");
-    }
-    case mojom::Operand::Kind::kConstant: {
-      // It's okay to use operand id as name directly since operand id is
-      // guaranteed to be unique.
-      return base::NumberToString(operand_id);
-    }
-    case mojom::Operand::Kind::kOutput: {
-      if (operand.name.has_value()) {
-        return operand.name.value();
-        // return base::JoinString({"output", operand.name.value()}, "_");
-      } else {
-        return base::NumberToString(operand_id);
-      }
-    }
-  }
+  std::string operand_name =
+      operand.name.has_value() ? operand.name.value() : "";
+  return GetOperandName(operand_name, operand_id);
 }
 
 std::string GraphBuilderOrt::GenerateNextOperandName() {
-  return base::NumberToString(next_operand_id_++);
+  return GetOperandName(kInserted, next_operand_id_++);
 }
 
 std::string GraphBuilderOrt::GenerateNextOperationName(std::string_view label) {
   return base::JoinString({label, base::NumberToString(next_operation_id_++)},
-                          "_");
+                          kUnderscore);
 }
 
 template <typename DataType>

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -221,9 +221,9 @@ const mojom::Operand& GraphBuilderOrt::GetOperand(uint64_t operand_id) {
 
 std::string GraphBuilderOrt::GetOperandNameById(uint64_t operand_id) {
   const mojom::Operand& operand = GetOperand(operand_id);
-  std::string operand_name =
+  std::string operand_label =
       operand.name.has_value() ? operand.name.value() : "";
-  return GetOperandName(operand_name, operand_id);
+  return GetOperandName(operand_label, operand_id);
 }
 
 std::string GraphBuilderOrt::GenerateNextOperandName() {

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -80,13 +80,8 @@ class GraphBuilderOrt {
   // Get the unique name of an existing operand by its id.
   std::string GetOperandNameById(uint64_t operand_id);
 
-  // Generate the unique name of a newly created operand using the
-  // `next_operand_id_`, and then increase the `next_operand_id_`.
-  // TODO(https://github.com/shiyi9801/chromium/issues/63): Make name generation
-  // more robust. The newly created operands should also have a unique id, so
-  // here they're named by their ids for now. However, it is still possible to
-  // have names that are the same as the graph's inputs/outputs provided by
-  // users. ONNX doesn't allow duplicate operand names.
+  // Generate the unique name of a newly created operand by combining a prefix
+  // "inserted" and `next_operand_id_`, and then increase `next_operand_id_`.
   std::string GenerateNextOperandName();
 
   // Generate the unique name of a newly created operation by combining the

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -42,6 +42,10 @@ concept IsSupportedTensorType = IsAnyOf<T, float, uint16_t, int64_t>;
 
 }  // namespace internal
 
+// The returned operand name has a format of "label_id". Adding operand id at
+// the end ensures that the name is unique.
+std::string GetOperandName(std::string_view label, uint64_t id);
+
 class GraphBuilderOrt {
   STACK_ALLOCATED();
 

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -29,29 +29,154 @@ namespace webnn::ort {
 
 namespace {
 
-std::vector<const OrtValue*> GetSharedLockedInputTensors(
-    const std::vector<scoped_refptr<QueueableResourceState<BufferContentOrt>>>&
-        buffers) {
-  std::vector<const OrtValue*> input_tensors;
-  input_tensors.reserve(buffers.size());
-  for (const auto& buffer : buffers) {
-    input_tensors.push_back(buffer->GetSharedLockedResource().tensor());
-  }
-  return input_tensors;
-}
+struct Session {
+  Session(ScopedOrtEnvPtr env,
+          ScopedOrtSessionPtr session,
+          std::vector<base::HeapArray<uint8_t>> external_data)
+      : external_data(std::move(external_data)),
+        env(std::move(env)),
+        session(std::move(session)) {}
+  Session(const Session&) = delete;
+  Session& operator=(const Session&) = delete;
+  ~Session() = default;
 
-std::vector<OrtValue*> GetExclusivelyLockedOutputTensors(
-    const std::vector<scoped_refptr<QueueableResourceState<BufferContentOrt>>>&
-        buffers) {
-  std::vector<OrtValue*> output_tensors;
-  output_tensors.reserve(buffers.size());
-  for (const auto& buffer : buffers) {
-    output_tensors.push_back(buffer->GetExclusivelyLockedResource()->tensor());
+  OrtSession* GetSession() { return session.Get(); }
+
+  std::vector<base::HeapArray<uint8_t>> external_data;
+
+  // `env` should be prior to `session`. That ensures releasing `env` after
+  // releasing the session. This avoids unloading the providers DLLs being
+  // used during `session` destruction.
+  ScopedOrtEnvPtr env;
+  ScopedOrtSessionPtr session;
+};
+
+base::flat_map<std::string,
+               scoped_refptr<QueueableResourceState<BufferContentOrt>>>
+ToNamedBufferStateMap(
+    const base::flat_map<std::string_view, WebNNTensorImpl*>& named_tensors) {
+  base::flat_map<std::string,
+                 scoped_refptr<QueueableResourceState<BufferContentOrt>>>
+      buffer_states;
+  buffer_states.reserve(named_tensors.size());
+
+  for (const auto& [name, tensor] : named_tensors) {
+    buffer_states.emplace(
+        name, static_cast<TensorImplOrt*>(tensor)->GetBufferState());
   }
-  return output_tensors;
+
+  return buffer_states;
 }
 
 }  // namespace
+
+// Represents the collection of resources associated with a particular graph.
+// These resources may outlive their associated `GraphImplOrt` instance while
+// executing the graph.
+class GraphImplOrt::ComputeResources {
+ public:
+  ComputeResources(std::unique_ptr<Session> session,
+                   base::flat_map<std::string, std::string>
+                       operand_input_name_to_onnx_input_name,
+                   base::flat_map<std::string, std::string>
+                       operand_output_name_to_onnx_output_name)
+      : operand_input_name_to_onnx_input_name_(
+            std::move(operand_input_name_to_onnx_input_name)),
+        operand_output_name_to_onnx_output_name_(
+            std::move(operand_output_name_to_onnx_output_name)),
+        session_(std::move(session)) {}
+
+  ~ComputeResources() = default;
+
+  // Run the model asynchronously in `base::ThreadPool`.
+  void OrtRunSync(
+      std::vector<std::pair<std::string, const OrtValue*>> named_input_tensors,
+      std::vector<std::pair<std::string, OrtValue*>> named_output_tensors) {
+    TRACE_EVENT0("gpu", "ort::GraphImplOrt::ComputeResources::OrtRunSync");
+
+    std::vector<const char*> input_names;
+    std::vector<const OrtValue*> input_tensors;
+    input_names.reserve(named_input_tensors.size());
+    input_tensors.reserve(named_input_tensors.size());
+    for (const auto& [name, tensor] : named_input_tensors) {
+      input_names.push_back(
+          operand_input_name_to_onnx_input_name_.at(name).data());
+      input_tensors.push_back(tensor);
+    }
+
+    std::vector<const char*> output_names;
+    std::vector<OrtValue*> output_tensors;
+    output_names.reserve(named_output_tensors.size());
+    output_tensors.reserve(named_output_tensors.size());
+    for (const auto& [name, tensor] : named_output_tensors) {
+      output_names.push_back(
+          operand_output_name_to_onnx_output_name_.at(name).data());
+      output_tensors.push_back(tensor);
+    }
+
+    const OrtApi* ort_api = GetOrtApi();
+    CHECK_STATUS(ort_api->Run(session_->GetSession(), nullptr,
+                              input_names.data(), input_tensors.data(),
+                              input_names.size(), output_names.data(),
+                              output_names.size(), output_tensors.data()));
+  }
+
+  // Run the model asynchronously in a thread owned by ort intra op thread pool.
+  void OrtRunAsync(
+      std::vector<std::pair<std::string, const OrtValue*>> named_input_tensors,
+      std::vector<std::pair<std::string, OrtValue*>> named_output_tensors,
+      base::OnceClosure completion_closure) {
+    TRACE_EVENT0("gpu", "ort::GraphImplOrt::ComputeResources::OrtRunAsync");
+
+    std::vector<const char*> input_names;
+    std::vector<const OrtValue*> input_tensors;
+    input_names.reserve(named_input_tensors.size());
+    input_tensors.reserve(named_input_tensors.size());
+    for (const auto& [name, tensor] : named_input_tensors) {
+      input_names.push_back(
+          operand_input_name_to_onnx_input_name_.at(name).data());
+      input_tensors.push_back(tensor);
+    }
+
+    std::vector<const char*> output_names;
+    std::vector<OrtValue*> output_tensors;
+    output_names.reserve(named_output_tensors.size());
+    output_tensors.reserve(named_output_tensors.size());
+    for (const auto& [name, tensor] : named_output_tensors) {
+      output_names.push_back(
+          operand_output_name_to_onnx_output_name_.at(name).data());
+      output_tensors.push_back(tensor);
+    }
+
+    const OrtApi* ort_api = GetOrtApi();
+    CHECK_STATUS(ort_api->RunAsync(
+        session_->GetSession(), nullptr, input_names.data(),
+        input_tensors.data(), input_names.size(), output_names.data(),
+        output_names.size(), output_tensors.data(),
+        &ComputeResources::OnOrtRunAsyncCompleted,
+        new base::OnceClosure(std::move(completion_closure))));
+  }
+
+  // This method is not run on the main thread, it's called by the ort.
+  static void OnOrtRunAsyncCompleted(void* user_data,
+                                     OrtValue** outputs,
+                                     size_t num_outputs,
+                                     OrtStatus* status) {
+    auto* completion_closure = static_cast<base::OnceClosure*>(user_data);
+    CHECK(!status);
+    CHECK(outputs);
+    std::move(*completion_closure).Run();
+    delete completion_closure;
+    completion_closure = nullptr;
+  }
+
+ private:
+  base::flat_map<std::string, std::string>
+      operand_input_name_to_onnx_input_name_;
+  base::flat_map<std::string, std::string>
+      operand_output_name_to_onnx_output_name_;
+  std::unique_ptr<Session> session_;
+};
 
 // static
 void GraphImplOrt::CreateAndBuild(
@@ -75,18 +200,8 @@ void GraphImplOrt::CreateAndBuild(
       std::move(wrapped_callback));
 }
 
-GraphImplOrt::Session::Session(
-    ScopedOrtEnvPtr env,
-    ScopedOrtSessionPtr session,
-    std::vector<base::HeapArray<uint8_t>> external_data)
-    : external_data(std::move(external_data)),
-      env(std::move(env)),
-      session(std::move(session)) {}
-
-GraphImplOrt::Session::~Session() = default;
-
 // static
-base::expected<std::unique_ptr<GraphImplOrt::Session>, mojom::ErrorPtr>
+base::expected<std::unique_ptr<GraphImplOrt::ComputeResources>, mojom::ErrorPtr>
 GraphImplOrt::CreateAndBuildOnBackgroundThread(
     mojom::GraphInfoPtr graph_info,
     mojom::CreateContextOptionsPtr context_options,
@@ -227,12 +342,34 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
                                               "Failed to build graph."));
   }
 
+  auto compute_session =
+      base::WrapUnique(new Session(std::move(env), std::move(session),
+                                   std::move(model_info->external_data)));
+
+  base::flat_map<std::string, std::string>
+      operand_input_name_to_onnx_input_name;
+  for (uint64_t id : graph_info->input_operands) {
+    std::string_view operand_name =
+        graph_info->id_to_operand_map.at(id)->name.value();
+    operand_input_name_to_onnx_input_name.emplace(
+        operand_name, GetOperandName(operand_name, id));
+  }
+  base::flat_map<std::string, std::string>
+      operand_output_name_to_onnx_output_name;
+  for (uint64_t id : graph_info->output_operands) {
+    std::string_view operand_name =
+        graph_info->id_to_operand_map.at(id)->name.value();
+    operand_output_name_to_onnx_output_name.emplace(
+        operand_name, GetOperandName(operand_name, id));
+  }
+
   // TODO: remove this log which is for temporary debugging purpose.
   LOG(ERROR) << "========= Running on ORT =============";
 
-  return base::WrapUnique(
-      new GraphImplOrt::Session(std::move(env), std::move(session),
-                                std::move(model_info->external_data)));
+  return base::WrapUnique(new GraphImplOrt::ComputeResources(
+      std::move(compute_session),
+      std::move(operand_input_name_to_onnx_input_name),
+      std::move(operand_output_name_to_onnx_output_name)));
 }
 
 // static
@@ -240,8 +377,8 @@ void GraphImplOrt::DidCreateAndBuild(
     base::WeakPtr<WebNNContextImpl> context,
     ComputeResourceInfo compute_resource_info,
     WebNNContextImpl::CreateGraphImplCallback callback,
-    base::expected<std::unique_ptr<GraphImplOrt::Session>, mojom::ErrorPtr>
-        result) {
+    base::expected<std::unique_ptr<GraphImplOrt::ComputeResources>,
+                   mojom::ErrorPtr> result) {
   if (!result.has_value()) {
     std::move(callback).Run(base::unexpected(std::move(result.error())));
     return;
@@ -258,100 +395,13 @@ void GraphImplOrt::DidCreateAndBuild(
       static_cast<ContextImplOrt*>(context.get()))));
 }
 
-// Represents the collection of resources associated with a particular graph.
-// These resources may outlive their associated `GraphImplOrt` instance while
-// executing the graph.
-class GraphImplOrt::ComputeResources {
- public:
-  ComputeResources(std::unique_ptr<GraphImplOrt::Session> session,
-                   const ComputeResourceInfo& compute_resource_info)
-      : session_(std::move(session)) {
-    size_t input_count =
-        compute_resource_info.input_names_to_descriptors.size();
-    size_t output_count =
-        compute_resource_info.output_names_to_descriptors.size();
-
-    input_names_storage_.reserve(input_count);
-    output_names_storage_.reserve(output_count);
-
-    input_names_.reserve(input_count);
-    output_names_.reserve(output_count);
-
-    for (const auto& [name, _] :
-         compute_resource_info.input_names_to_descriptors) {
-      input_names_storage_.push_back(name);
-      input_names_.push_back(input_names_storage_.back().data());
-    }
-    for (const auto& [name, _] :
-         compute_resource_info.output_names_to_descriptors) {
-      output_names_storage_.push_back(name);
-      output_names_.push_back(output_names_storage_.back().data());
-    }
-  }
-
-  ~ComputeResources() = default;
-
-  // Run the model asynchronously in `base::ThreadPool`.
-  void OrtRunSync(std::vector<const OrtValue*> input_tensors,
-                  std::vector<OrtValue*> output_tensors) {
-    TRACE_EVENT0("gpu", "ort::GraphImplOrt::ComputeResources::OrtRunSync");
-
-    CHECK_EQ(input_tensors.size(), input_names_.size());
-    CHECK_EQ(output_tensors.size(), output_names_.size());
-    const OrtApi* ort_api = GetOrtApi();
-    CHECK_STATUS(ort_api->Run(session_->GetSession(), nullptr,
-                              input_names_.data(), input_tensors.data(),
-                              input_names_.size(), output_names_.data(),
-                              output_names_.size(), output_tensors.data()));
-  }
-
-  // Run the model asynchronously in a thread owned by ort intra op thread pool.
-  void OrtRunAsync(std::vector<const OrtValue*> input_tensors,
-                   std::vector<OrtValue*> output_tensors,
-                   base::OnceClosure completion_closure) {
-    CHECK_EQ(input_tensors.size(), input_names_.size());
-    CHECK_EQ(output_tensors.size(), output_names_.size());
-    const OrtApi* ort_api = GetOrtApi();
-
-    CHECK_STATUS(ort_api->RunAsync(
-        session_->GetSession(), nullptr, input_names_.data(),
-        input_tensors.data(), input_names_.size(), output_names_.data(),
-        output_names_.size(), output_tensors.data(),
-        &ComputeResources::OnOrtRunAsyncCompleted,
-        new base::OnceClosure(std::move(completion_closure))));
-  }
-
-  // This method is not run on the main thread, it's called by the ort.
-  static void OnOrtRunAsyncCompleted(void* user_data,
-                                     OrtValue** outputs,
-                                     size_t num_outputs,
-                                     OrtStatus* status) {
-    auto* completion_closure = static_cast<base::OnceClosure*>(user_data);
-    CHECK(!status);
-    CHECK(outputs);
-    std::move(*completion_closure).Run();
-    delete completion_closure;
-    completion_closure = nullptr;
-  }
-
- private:
-  std::unique_ptr<GraphImplOrt::Session> session_;
-  std::vector<std::string> input_names_storage_;
-  std::vector<std::string> output_names_storage_;
-  // Pointers to the strings in `input_names_storage_`
-  std::vector<const char*> input_names_;
-  // Pointers to the strings in `output_names_storage_`
-  std::vector<const char*> output_names_;
-};
-
 GraphImplOrt::~GraphImplOrt() = default;
 
-GraphImplOrt::GraphImplOrt(ComputeResourceInfo compute_resource_info,
-                           std::unique_ptr<GraphImplOrt::Session> session,
-                           ContextImplOrt* context)
+GraphImplOrt::GraphImplOrt(
+    ComputeResourceInfo compute_resource_info,
+    std::unique_ptr<GraphImplOrt::ComputeResources> compute_resources,
+    ContextImplOrt* context)
     : WebNNGraphImpl(context, std::move(compute_resource_info)) {
-  std::unique_ptr<ComputeResources> compute_resources = base::WrapUnique(
-      new ComputeResources(std::move(session), this->compute_resource_info()));
   compute_resources_state_ =
       base::MakeRefCounted<QueueableResourceState<ComputeResources>>(
           std::move(compute_resources));
@@ -364,27 +414,18 @@ void GraphImplOrt::DispatchImpl(
         named_output_tensors) {
   TRACE_EVENT0("gpu", "ort::GraphImplOrt::DispatchImpl");
 
-  // Since the flat_map is ordered, the order of the tensors is guaranteed to be
-  // the same as the order of the input/output names.
-  std::vector<scoped_refptr<QueueableResourceState<BufferContentOrt>>>
-      input_buffer_states, output_buffer_states;
-  input_buffer_states.reserve(named_input_tensors.size());
-  output_buffer_states.reserve(named_output_tensors.size());
-
-  for (const auto& [_, tensor] : named_input_tensors) {
-    input_buffer_states.emplace_back(
-        static_cast<TensorImplOrt*>(tensor)->GetBufferState());
-  }
-  for (const auto& [_, tensor] : named_output_tensors) {
-    output_buffer_states.emplace_back(
-        static_cast<TensorImplOrt*>(tensor)->GetBufferState());
-  }
+  base::flat_map<std::string,
+                 scoped_refptr<QueueableResourceState<BufferContentOrt>>>
+      named_input_buffer_states = ToNamedBufferStateMap(named_input_tensors);
+  base::flat_map<std::string,
+                 scoped_refptr<QueueableResourceState<BufferContentOrt>>>
+      named_output_buffer_states = ToNamedBufferStateMap(named_output_tensors);
 
   // Input tensors will be read from while the graph is executing, so lock them
   // them as shared/read-only.
   std::vector<scoped_refptr<QueueableResourceStateBase>> shared_resources;
   shared_resources.reserve(named_input_tensors.size());
-  for (const auto& buffer_state : input_buffer_states) {
+  for (const auto& [_, buffer_state] : named_input_buffer_states) {
     shared_resources.push_back(buffer_state);
   }
 
@@ -393,7 +434,7 @@ void GraphImplOrt::DispatchImpl(
   // Extra +1 is for the compute resources.
   exclusive_resources.reserve(1 + named_output_tensors.size());
   exclusive_resources.push_back(compute_resources_state_);
-  for (const auto& buffer_state : output_buffer_states) {
+  for (const auto& [_, buffer_state] : named_output_buffer_states) {
     exclusive_resources.push_back(buffer_state);
   }
 
@@ -402,18 +443,32 @@ void GraphImplOrt::DispatchImpl(
       base::BindOnce(
           [](scoped_refptr<QueueableResourceState<ComputeResources>>
                  compute_resources_state,
-             std::vector<scoped_refptr<
-                 QueueableResourceState<BufferContentOrt>>> input_buffer_states,
-             std::vector<
+             base::flat_map<
+                 std::string,
                  scoped_refptr<QueueableResourceState<BufferContentOrt>>>
-                 output_buffer_states,
+                 named_input_buffer_states,
+             base::flat_map<
+                 std::string,
+                 scoped_refptr<QueueableResourceState<BufferContentOrt>>>
+                 named_output_buffer_states,
              base::OnceClosure completion_closure) {
             ComputeResources* raw_compute_resources =
                 compute_resources_state->GetExclusivelyLockedResource();
-            std::vector<const OrtValue*> input_tensors =
-                GetSharedLockedInputTensors(input_buffer_states);
-            std::vector<OrtValue*> output_tensors =
-                GetExclusivelyLockedOutputTensors(output_buffer_states);
+
+            std::vector<std::pair<std::string, const OrtValue*>>
+                named_input_tensors;
+            named_input_tensors.reserve(named_input_buffer_states.size());
+            std::vector<std::pair<std::string, OrtValue*>> named_output_tensors;
+            named_output_tensors.reserve(named_output_buffer_states.size());
+
+            for (const auto& [name, buffer] : named_input_buffer_states) {
+              named_input_tensors.emplace_back(
+                  name, buffer->GetSharedLockedResource().tensor());
+            }
+            for (const auto& [name, buffer] : named_output_buffer_states) {
+              named_output_tensors.emplace_back(
+                  name, buffer->GetExclusivelyLockedResource()->tensor());
+            }
 
             // TODO(https://github.com/shiyi9801/chromium/issues/57): Decide
             // whether to use `OrtApi::RunAsync` or `OrtApi::Run` here.
@@ -424,12 +479,12 @@ void GraphImplOrt::DispatchImpl(
                 FROM_HERE,
                 base::BindOnce(&ComputeResources::OrtRunSync,
                                base::Unretained(raw_compute_resources),
-                               std::move(input_tensors),
-                               std::move(output_tensors)),
+                               std::move(named_input_tensors),
+                               std::move(named_output_tensors)),
                 std::move(completion_closure));
           },
-          compute_resources_state_, std::move(input_buffer_states),
-          std::move(output_buffer_states)));
+          compute_resources_state_, std::move(named_input_buffer_states),
+          std::move(named_output_buffer_states)));
 
   task->Enqueue();
 }

--- a/services/webnn/ort/graph_impl_ort.h
+++ b/services/webnn/ort/graph_impl_ort.h
@@ -51,31 +51,14 @@ class GraphImplOrt final : public WebNNGraphImpl {
   GraphImplOrt& operator=(const GraphImplOrt&) = delete;
   ~GraphImplOrt() override;
 
-  struct Session {
-    Session(ScopedOrtEnvPtr env,
-            ScopedOrtSessionPtr session,
-            std::vector<base::HeapArray<uint8_t>> external_data);
-    Session(const Session&) = delete;
-    Session& operator=(const Session&) = delete;
-    ~Session();
-
-    OrtSession* GetSession() { return session.Get(); }
-
-    std::vector<base::HeapArray<uint8_t>> external_data;
-
-    // `env` should be prior to `session`. That ensures releasing `env` after
-    // releasing the session. This avoids unloading the providers DLLs being
-    // used during `session` destruction.
-    ScopedOrtEnvPtr env;
-    ScopedOrtSessionPtr session;
-  };
-
  private:
+  class ComputeResources;
+
   GraphImplOrt(ComputeResourceInfo compute_resource_info,
-               std::unique_ptr<GraphImplOrt::Session> session,
+               std::unique_ptr<ComputeResources> compute_resources,
                ContextImplOrt* context);
 
-  static base::expected<std::unique_ptr<GraphImplOrt::Session>, mojom::ErrorPtr>
+  static base::expected<std::unique_ptr<ComputeResources>, mojom::ErrorPtr>
   CreateAndBuildOnBackgroundThread(
       mojom::GraphInfoPtr graph_info,
       mojom::CreateContextOptionsPtr context_options,
@@ -87,10 +70,8 @@ class GraphImplOrt final : public WebNNGraphImpl {
       base::WeakPtr<WebNNContextImpl> context,
       ComputeResourceInfo compute_resource_info,
       WebNNContextImpl::CreateGraphImplCallback callback,
-      base::expected<std::unique_ptr<GraphImplOrt::Session>, mojom::ErrorPtr>
+      base::expected<std::unique_ptr<ComputeResources>, mojom::ErrorPtr>
           result);
-
-  class ComputeResources;
 
   // Execute the compiled platform graph asynchronously. The inputs were
   // validated in base class so we can use them to compute directly.


### PR DESCRIPTION
Fix #63

This PR renames the operands to make sure each name is unique, refactors `ComputeResources` for using new operands names.