### PR TITLE
Introduce flag `--webnn-ort-disable-cpu-falback` to disable the fallback to CPU

### DIFF
--- a/content/browser/gpu/gpu_process_host.cc
+++ b/content/browser/gpu/gpu_process_host.cc
@@ -331,6 +331,7 @@ static const char* const kSwitchNames[] = {
     switches::kWebNNUseOrt,
     switches::kWebNNOrtDumpModel,
     switches::kWebNNOrtUseOpenvino,
+    switches::kWebNNOrtDisableCpuFallback,
 #endif
 };
 

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -24,6 +24,7 @@
 #include "services/webnn/webnn_constant_operand.h"
 #include "services/webnn/webnn_graph_impl.h"
 #include "services/webnn/webnn_switches.h"
+#include "third_party/onnxruntime_headers/src/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h"
 
 namespace webnn::ort {
 
@@ -196,6 +197,13 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
     // tensors created with `CreateTensorWithDataAsOrtValue()` or
     // `CreateTensorWithDataAndDeleterAsOrtValue()` when ORT Model Builder API
     // supports it.
+  }
+
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kWebNNOrtDisableCpuFallback)) {
+    CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
+        session_options, /*config_key=*/kOrtSessionOptionsDisableCPUEPFallback,
+        /*config_value=*/"1"));
   }
 
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -38,6 +38,10 @@ inline constexpr char kWebNNOrtDumpModel[] = "webnn-ort-dump-model";
 // Use OpenVINO EP of ONNX Runtime, WebNN device type will map OpenVINO device
 // type.
 inline constexpr char kWebNNOrtUseOpenvino[] = "webnn-ort-use-openvino";
+
+// Disable CPU fallback for OpenVINO EP.
+inline constexpr char kWebNNOrtDisableCpuFallback[] =
+    "webnn-ort-disable-cpu-fallback";
 #endif  // BUILDFLAG(WEBNN_USE_ORT)
 
 }  // namespace switches


### PR DESCRIPTION
Use flag `--webnn-ort-disable-cpu-falback` to disable the fallback to ORT CPU EP, which utilizes config `kOrtSessionOptionsDisableCPUEPFallback`:

```
// Graph nodes that are not supported by the execution providers (EPs) explicitly added to the session are
// assigned (i.e., "fallback") to the CPU EP by default.
//
// This option allows the user to disable the fallback of unsupported graph nodes to the CPU EP.
// If this option is set to "1", session creation will fail if the execution providers other than the CPU EP cannot
// fully support all of the nodes in the graph.
//
// It is invalid to set this option and explicitly add the CPU EP to the session. In this case, session creation
// will also fail with an error.
//
// Option values:
// - "0": CPU EP fallback is not disabled. [DEFAULT]
// - "1": CPU EP fallback is disabled.
static const char* const kOrtSessionOptionsDisableCPUEPFallback = "session.disable_cpu_ep_fallback";
```


It can also disable the fallback from OV NPU to OV CPU:

```
  pi.so_disable_cpu_ep_fallback = config_options.GetConfigOrDefault(kOrtSessionOptionsDisableCPUEPFallback, "0") == "1";
```

https://github.com/microsoft/onnxruntime/blob/6d2b36e18fe128a343492ad4b310ed5426ed4218/onnxruntime/core/providers/openvino/openvino_provider_factory.cc#L18


With this flag on, Segment Anything will fail on OV NPU with error:
>[9892:11592:0220/160554.281:ERROR:graph_impl_ort.cc(267)] : [WebNN] Failed to call GetOrtModelBuilderApi()->CreateSessionFromModel( env, model_info->model, session_options, session.GetAddressOf()): Exception during initialization: ZE_RESULT_ERROR_INVALID_ARGUMENT, code 0x78000004
>Model needs to be recompiled
