### PR TITLE
introduce "--webnn-ort-use-ov-gpu-fp32"

### DIFF
--- a/content/browser/gpu/gpu_process_host.cc
+++ b/content/browser/gpu/gpu_process_host.cc
@@ -332,6 +332,7 @@ static const char* const kSwitchNames[] = {
     switches::kWebNNOrtDumpModel,
     switches::kWebNNOrtUseOpenvino,
     switches::kWebNNOrtDisableCpuFallback,
+    switches::kWebNNOrtUseOVGpuFP32,
 #endif
 };
 

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -215,7 +215,13 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
         break;
       }
       case mojom::CreateContextOptions::Device::kGpu: {
-        openvino_device_type = "GPU";
+        bool use_gpu_fp32 = base::CommandLine::ForCurrentProcess()->HasSwitch(
+            switches::kWebNNOrtUseOVGpuFP32);
+        // "GPU" will use FP16 inference precision by default. Notice that the
+        // "GPU_FP32" may be deprecated in the future.
+        // TODO(https://github.com/shiyi9801/chromium/issues/159): Set the
+        // inference precision or execution mode for GPU separately.
+        openvino_device_type = use_gpu_fp32 ? "GPU_FP32" : "GPU";
         break;
       }
       case mojom::CreateContextOptions::Device::kNpu: {

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -42,6 +42,11 @@ inline constexpr char kWebNNOrtUseOpenvino[] = "webnn-ort-use-openvino";
 // Disable CPU fallback for OpenVINO EP.
 inline constexpr char kWebNNOrtDisableCpuFallback[] =
     "webnn-ort-disable-cpu-fallback";
+
+// For GPU, OV EP will use FP16 inference precision by default, this switch will
+// force OV EP to use FP32 inference precision to get better accuracy, but it
+// may result in decreased performance.
+inline constexpr char kWebNNOrtUseOVGpuFP32[] = "webnn-ort-use-ov-gpu-fp32";
 #endif  // BUILDFLAG(WEBNN_USE_ORT)
 
 }  // namespace switches


### PR DESCRIPTION
This switch will force OV EP to use FP32 inference precision for GPU to get better accuracy, but it may result in decreased performance.

PTAL, thanks!

cc/ @bruceDai @lisa0314 @miaobin 