### PR TITLE
introduce "--webnn-ort-ov-gpu-precision" to specify gpu precision

### DIFF
--- a/content/browser/gpu/gpu_process_host.cc
+++ b/content/browser/gpu/gpu_process_host.cc
@@ -332,7 +332,7 @@ static const char* const kSwitchNames[] = {
     switches::kWebNNOrtDumpModel,
     switches::kWebNNOrtUseOpenvino,
     switches::kWebNNOrtDisableCpuFallback,
-    switches::kWebNNOrtUseOVGpuFP32,
+    switches::kWebNNOrtOVGpuPrecision,
 #endif
 };
 

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -30,13 +30,42 @@ namespace webnn::ort {
 
 namespace {
 
-// These keys and values must align with the implementation of the ORT OpenVINO
-// EP:
+// These OpenVINO EP specific keys and values must align with the implementation
+// of the ORT OpenVINO EP. Misalignment of keys will be ignored. Misalignment of
+// values may cause errors.
+//
+// According to
 // https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
-// Misalignment of keys will be ignored. Misalignment of values may cause
-// errors.
+// and
+// https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#summary-of-options,
+// valid keys and values should be:
+//
+// -[device_type]: "CPU", "GPU", "NPU", "GPU.x" where x = 0,1,2 and so on or
+// from "HETERO"/"MULTI"/"AUTO" options.
+// -[precision]: "FP32", "FP16", "ACCURACY". You needn't specify the precision
+// for CPU and NPU, because CPU only supports FP32 by default and NPU only
+// supports FP16 by default. GPU uses FP16 by default.
+// -[num_of_threads]: Any unsigned positive number other than 0. Specifies the
+// number of threads at runtime.
+// -[load_config]: JSON config map to load custom OV parameters.
+// -[cache_dir]: Path to dump and load the blobs for the model caching/kernel
+// caching.
+// -[model_priority]: "LOW", "MEDIUM", "HIGH", "DEFAULT". High-level OpenVINO
+// model priority hint.
+// -[num_streams]: Any unsigned positive number other than 0. specifies the
+// number of parallel inference requests.
+// -[context]: OpenCL Context with void* type.
+// -[enable_opencl_throttling]: "true", "false" or "True", "False". Enables
+// OpenCL queue throttling for GPU device.
+// -[disable_dynamic_shapes]: "true", "false" or "True", "False". Always true
+// for NPU plugin. Rewrite dynamic shaped models to static shape at runtime and
+// execute.
+// -[enable_qdq_optimizer]: "true", "false" or "True", "False". Enables QDQ
+// pruning for efficient inference latency with NPU.
+//
+// Keys:
 constexpr char kOVPrecision[] = "precision";
-
+// Values:
 constexpr char kOVDeviceType[] = "device_type";
 constexpr char kOVDeviceGPU[] = "GPU";
 constexpr char kOVDeviceCPU[] = "CPU";

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -30,6 +30,18 @@ namespace webnn::ort {
 
 namespace {
 
+// These keys and values must align with the implementation of the ORT OpenVINO
+// EP:
+// https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+// Misalignment of keys will be ignored. Misalignment of values may cause
+// errors.
+constexpr char kOVPrecision[] = "precision";
+
+constexpr char kOVDeviceType[] = "device_type";
+constexpr char kOVDeviceGPU[] = "GPU";
+constexpr char kOVDeviceCPU[] = "CPU";
+constexpr char kOVDeviceNPU[] = "NPU";
+
 struct Session {
   Session(ScopedOrtEnvPtr env,
           ScopedOrtSessionPtr session,
@@ -206,26 +218,34 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
         /*config_value=*/"1"));
   }
 
+  std::vector<const char*> provider_options_keys;
+  std::vector<const char*> provider_options_values;
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
           switches::kWebNNOrtUseOpenvino)) {
-    std::string openvino_device_type;
     switch (device_type) {
       case mojom::CreateContextOptions::Device::kCpu: {
-        openvino_device_type = "CPU";
+        provider_options_keys.push_back(kOVDeviceType);
+        provider_options_values.push_back(kOVDeviceCPU);
         break;
       }
       case mojom::CreateContextOptions::Device::kGpu: {
-        bool use_gpu_fp32 = base::CommandLine::ForCurrentProcess()->HasSwitch(
-            switches::kWebNNOrtUseOVGpuFP32);
-        // "GPU" will use FP16 inference precision by default. Notice that the
-        // "GPU_FP32" may be deprecated in the future.
-        // TODO(https://github.com/shiyi9801/chromium/issues/159): Set the
-        // inference precision or execution mode for GPU separately.
-        openvino_device_type = use_gpu_fp32 ? "GPU_FP32" : "GPU";
+        provider_options_keys.push_back(kOVDeviceType);
+        provider_options_values.push_back(kOVDeviceGPU);
+
+        // "GPU" will use FP16 inference precision by default.
+        if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+                switches::kWebNNOrtOVGpuPrecision)) {
+          std::string gpu_precision =
+              base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
+                  switches::kWebNNOrtOVGpuPrecision);
+          provider_options_keys.push_back(kOVPrecision);
+          provider_options_values.push_back(gpu_precision.data());
+        }
         break;
       }
       case mojom::CreateContextOptions::Device::kNpu: {
-        openvino_device_type = "NPU";
+        provider_options_keys.push_back(kOVDeviceType);
+        provider_options_values.push_back(kOVDeviceNPU);
         break;
       }
     }
@@ -236,13 +256,11 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
     CALL_ORT_FUNC(ort_api->SetSessionGraphOptimizationLevel(
         session_options, GraphOptimizationLevel::ORT_DISABLE_ALL));
 
-    OrtOpenVINOProviderOptions openvino_options;
-    openvino_options.device_type = openvino_device_type.c_str();
-
-    // TODO(https://github.com/shiyi9801/chromium/issues/74): Fail early when
-    // creating the context if the OpenVINO EP is not supported.
-    if (ORT_CALL_FAILED(ort_api->SessionOptionsAppendExecutionProvider_OpenVINO(
-            session_options, &openvino_options))) {
+    if (ORT_CALL_FAILED(
+            ort_api->SessionOptionsAppendExecutionProvider_OpenVINO_V2(
+                session_options, provider_options_keys.data(),
+                provider_options_values.data(),
+                provider_options_keys.size()))) {
       return base::unexpected(
           mojom::Error::New(mojom::Error::Code::kUnknownError,
                             "OnnxRuntime OpenVINO EP is not supported."));

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -33,35 +33,10 @@ namespace {
 // These OpenVINO EP specific keys and values must align with the implementation
 // of the ORT OpenVINO EP. Misalignment of keys will be ignored. Misalignment of
 // values may cause errors.
-//
-// According to
+// More details can be found at:
 // https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
 // and
 // https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#summary-of-options,
-// valid keys and values should be:
-//
-// -[device_type]: "CPU", "GPU", "NPU", "GPU.x" where x = 0,1,2 and so on or
-// from "HETERO"/"MULTI"/"AUTO" options.
-// -[precision]: "FP32", "FP16", "ACCURACY". You needn't specify the precision
-// for CPU and NPU, because CPU only supports FP32 by default and NPU only
-// supports FP16 by default. GPU uses FP16 by default.
-// -[num_of_threads]: Any unsigned positive number other than 0. Specifies the
-// number of threads at runtime.
-// -[load_config]: JSON config map to load custom OV parameters.
-// -[cache_dir]: Path to dump and load the blobs for the model caching/kernel
-// caching.
-// -[model_priority]: "LOW", "MEDIUM", "HIGH", "DEFAULT". High-level OpenVINO
-// model priority hint.
-// -[num_streams]: Any unsigned positive number other than 0. specifies the
-// number of parallel inference requests.
-// -[context]: OpenCL Context with void* type.
-// -[enable_opencl_throttling]: "true", "false" or "True", "False". Enables
-// OpenCL queue throttling for GPU device.
-// -[disable_dynamic_shapes]: "true", "false" or "True", "False". Always true
-// for NPU plugin. Rewrite dynamic shaped models to static shape at runtime and
-// execute.
-// -[enable_qdq_optimizer]: "true", "false" or "True", "False". Enables QDQ
-// pruning for efficient inference latency with NPU.
 //
 // Keys:
 constexpr char kOVPrecision[] = "precision";

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -56,7 +56,7 @@ inline constexpr char kWebNNOrtDisableCpuFallback[] =
 // "ov::hint::ExecutionMode::ACCURACY"
 //
 // More details for the inference precision and execution mode can be found at
-// https://docs.openvino.ai/2025/openvino-workflow/running-inference/optimize-inference/precision-control.html.
+// https://docs.openvino.ai/2025/openvino-workflow/running-inference/optimize-inference/precision-control.html
 inline constexpr char kWebNNOrtOVGpuPrecision[] = "webnn-ort-ov-gpu-precision";
 #endif  // BUILDFLAG(WEBNN_USE_ORT)
 

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -44,10 +44,19 @@ inline constexpr char kWebNNOrtDisableCpuFallback[] =
     "webnn-ort-disable-cpu-fallback";
 
 // For GPU, OV EP will use FP16 inference precision by default. You can specify
-// the flag to use FP32 or ACCURACY inference precision to get better accuracy,
-// but it may result in decreased performance.
+// the flag to use FP32 or ACCURACY to get better accuracy, but it may result in
+// decreased performance.
+//
 // Usage1: --webnn-ort-ov-gpu-precision=FP32
+// It will set underlying OV inference precison to
+// "ov::hint::inference_precision(ov::element::f32)".
+//
 // Usage2: --webnn-ort-ov-gpu-precision=ACCURACY
+// It will set underlying OV execution mode to
+// "ov::hint::ExecutionMode::ACCURACY"
+//
+// More details for the inference precision and execution mode can be found at
+// https://docs.openvino.ai/2025/openvino-workflow/running-inference/optimize-inference/precision-control.html.
 inline constexpr char kWebNNOrtOVGpuPrecision[] = "webnn-ort-ov-gpu-precision";
 #endif  // BUILDFLAG(WEBNN_USE_ORT)
 

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -43,10 +43,12 @@ inline constexpr char kWebNNOrtUseOpenvino[] = "webnn-ort-use-openvino";
 inline constexpr char kWebNNOrtDisableCpuFallback[] =
     "webnn-ort-disable-cpu-fallback";
 
-// For GPU, OV EP will use FP16 inference precision by default, this switch will
-// force OV EP to use FP32 inference precision to get better accuracy, but it
-// may result in decreased performance.
-inline constexpr char kWebNNOrtUseOVGpuFP32[] = "webnn-ort-use-ov-gpu-fp32";
+// For GPU, OV EP will use FP16 inference precision by default. You can specify
+// the flag to use FP32 or ACCURACY inference precision to get better accuracy,
+// but it may result in decreased performance.
+// Usage1: --webnn-ort-ov-gpu-precision=FP32
+// Usage2: --webnn-ort-ov-gpu-precision=ACCURACY
+inline constexpr char kWebNNOrtOVGpuPrecision[] = "webnn-ort-ov-gpu-precision";
 #endif  // BUILDFLAG(WEBNN_USE_ORT)
 
 }  // namespace switches


### PR DESCRIPTION
Change the `--webnn-ort-use-ov-gpu-fp32` flag to `--webnn-ort-ov-gpu-precision`

You can specify the flag to use `FP32` or `ACCURACY` inference precision:
Usage1: `--webnn-ort-ov-gpu-precision=FP32`
Usage2: `--webnn-ort-ov-gpu-precision=ACCURACY`

`--webnn-ort-ov-gpu-precision=ACCURACY` will let OV EP GPU use ACCURACY execution mode. As my observation, this mode will not decrease the SD Turbo's inference time a lot, but can increase the pass rate of many ops' wpt tests (resolve the accuracy failure). We can test more with this flag.

see https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/openvino/backends/basic_backend.cc#L167

PTAL, thanks! 
cc/ @brucedai @lisa0314 @miaobin 