### PR TITLE
Add OV EP support for dumping compiled model

### DIFF
--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -194,22 +194,30 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
                                               "Failed to create graph."));
   }
 
-  // TODO(https://github.com/shiyi9801/chromium/issues/72): Investigate if there
-  // is another way to dump the model for OpenVINO EP.
-  // OpenVINO EP doesn't support dumping the optimized model since it contains
-  // compiled nodes which cannnot be serialized.
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kWebNNOrtDumpModel) &&
-      !base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kWebNNOrtUseOpenvino)) {
+          switches::kWebNNOrtDumpModel)) {
     static uint64_t dump_count = 0;
     base::FilePath dump_directory =
         base::CommandLine::ForCurrentProcess()->GetSwitchValuePath(
             switches::kWebNNOrtDumpModel);
     base::FilePath dump_path = dump_directory.AppendASCII(
         base::StringPrintf("model%d.onnx", dump_count++));
-    CALL_ORT_FUNC(ort_api->SetOptimizedModelFilePath(
-        session_options, dump_path.value().c_str()));
+
+    if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
+            switches::kWebNNOrtUseOpenvino)) {
+      CALL_ORT_FUNC(ort_api->SetOptimizedModelFilePath(
+          session_options, dump_path.value().c_str()));
+    } else {
+      CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
+          session_options, kOrtSessionOptionEpContextEnable,
+          /*config_value=*/"1"));
+      CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
+          session_options, kOrtSessionOptionEpContextEmbedMode,
+          /*config_value=*/"1"));
+      CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
+          session_options, kOrtSessionOptionEpContextFilePath,
+          base::SysWideToUTF8(dump_path.value()).c_str()));
+    }
 
     // TODO(https://github.com/shiyi9801/chromium/issues/54): Support saving
     // tensors created with `CreateTensorWithDataAsOrtValue()` or

--- a/services/webnn/ort/ort_model_builder.cc
+++ b/services/webnn/ort/ort_model_builder.cc
@@ -12,8 +12,15 @@ namespace webnn {
 
 namespace {
 
+// Domains
 constexpr char kOrtDomainName[] = "";
+constexpr char kMSDomainName[] = "com.microsoft";
+
+// Opsets
 constexpr int32_t kOrtOpsetVersion = 21;
+// EPContext op is used for exporting the EP context cache model.
+// https://onnxruntime.ai/docs/execution-providers/EP-Context-Design.html#onnxruntime-ep-context-cache-feature-design
+constexpr int32_t kEPContextOpsetVersion = 1;
 
 // Define the minimum size(in bytes) to use external data.
 constexpr size_t kMinExternalDataSize = 128;
@@ -208,8 +215,9 @@ OrtModelBuilder::BuildAndTakeModelInfo() {
   CHECK_STATUS(GetOrtModelBuilderApi()->SetGraphOutputs(
       graph_, graph_outputs.data(), graph_outputs.size()));
 
-  std::vector<const char*> domain_names = {kOrtDomainName};
-  std::vector<int32_t> opset_versions = {kOrtOpsetVersion};
+  std::array<const char*, 2> domain_names = {kOrtDomainName, kMSDomainName};
+  std::array<int32_t, 2> opset_versions = {kOrtOpsetVersion,
+                                           kEPContextOpsetVersion};
 
   CHECK_STATUS(GetOrtModelBuilderApi()->CreateModel(
       domain_names.data(), opset_versions.data(), domain_names.size(),

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -63,6 +63,7 @@ inline constexpr char kWebNNOrtOVGpuPrecision[] = "webnn-ort-ov-gpu-precision";
 // --webnn-ort-use-ov-model-cache. Note, the folder needs to be accessible from
 // the GPU process sandbox or --no-sandbox must be used. Usage: --no-sandbox
 // --webnn-ort-use-ov-model-cache=./ModelCache
+// This switch doesn't work if --webnn-ort-dump-model is enabled.
 inline constexpr char kWebNNOrtUseOVModelCache[] =
     "webnn-ort-use-ov-model-cache";
 #endif  // BUILDFLAG(WEBNN_USE_ORT)


### PR DESCRIPTION
OV EP relies on a contribute op called EPContext defined in "com.microsoft" domain to export compiled model, see [EP Context Op Schema](https://onnxruntime.ai/docs/execution-providers/EP-Context-Design.html#epcontext-op-schema) for more information.

Exported model looks like this
![image](https://github.com/user-attachments/assets/a54b1275-7d93-4f5e-bbf7-8cb38ed000c3)

Fix #72