### PR TITLE
add `--webnn-ort-use-dml` switch to enable ort DML EP

### DIFF
--- a/content/browser/gpu/gpu_process_host.cc
+++ b/content/browser/gpu/gpu_process_host.cc
@@ -330,6 +330,7 @@ static const char* const kSwitchNames[] = {
 #if BUILDFLAG(WEBNN_USE_ORT)
     switches::kWebNNUseOrt,
     switches::kWebNNOrtDumpModel,
+    switches::kWebNNOrtUseDml,
     switches::kWebNNOrtUseOpenvino,
     switches::kWebNNOrtDisableCpuFallback,
     switches::kWebNNOrtOVGpuPrecision,

--- a/content/browser/gpu/gpu_process_host.cc
+++ b/content/browser/gpu/gpu_process_host.cc
@@ -330,7 +330,7 @@ static const char* const kSwitchNames[] = {
 #if BUILDFLAG(WEBNN_USE_ORT)
     switches::kWebNNUseOrt,
     switches::kWebNNOrtDumpModel,
-    switches::kWebNNOrtUseDml,
+    switches::kWebNNOrtUseDmlGpu,
     switches::kWebNNOrtUseOpenvino,
     switches::kWebNNOrtDisableCpuFallback,
     switches::kWebNNOrtOVGpuPrecision,

--- a/services/webnn/ort/context_impl_ort.cc
+++ b/services/webnn/ort/context_impl_ort.cc
@@ -172,16 +172,21 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
           mojom::Error::New(mojom::Error::Code::kUnknownError,
                             "OnnxRuntime OpenVINO EP is not supported."));
     }
+#if BUILDFLAG(IS_WIN)
   } else if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-                 switches::kWebNNOrtUseDml) &&
+                 switches::kWebNNOrtUseDmlGpu) &&
              device_type == mojom::CreateContextOptions::Device::kGpu) {
     CALL_ORT_FUNC(ort_api->SetSessionGraphOptimizationLevel(
         session_options.get(), GraphOptimizationLevel::ORT_ENABLE_BASIC));
     const OrtDmlApi* ort_dml_api = GetOrtDmlApi();
+    CHECK(ort_dml_api);
+    // Currently use the default device_id=0, which is typically the primary
+    // display GPU installed on the system.
     CALL_ORT_FUNC(ort_dml_api->SessionOptionsAppendExecutionProvider_DML(
-        session_options.get(), 0));
+        session_options.get(), /*device_id=*/0));
     CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
         session_options.get(), "ep.dml.disable_graph_fusion", "1"));
+#endif  // BUILDFLAG(IS_WIN)
   } else {
     // Use CPU EP by default.
     //

--- a/services/webnn/ort/context_impl_ort.cc
+++ b/services/webnn/ort/context_impl_ort.cc
@@ -172,6 +172,16 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
           mojom::Error::New(mojom::Error::Code::kUnknownError,
                             "OnnxRuntime OpenVINO EP is not supported."));
     }
+  } else if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+                 switches::kWebNNOrtUseDml) &&
+             device_type == mojom::CreateContextOptions::Device::kGpu) {
+    CALL_ORT_FUNC(ort_api->SetSessionGraphOptimizationLevel(
+        session_options.get(), GraphOptimizationLevel::ORT_ENABLE_BASIC));
+    const OrtDmlApi* ort_dml_api = GetOrtDmlApi();
+    CALL_ORT_FUNC(ort_dml_api->SessionOptionsAppendExecutionProvider_DML(
+        session_options.get(), 0));
+    CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
+        session_options.get(), "ep.dml.disable_graph_fusion", "1"));
   } else {
     // Use CPU EP by default.
     //

--- a/services/webnn/ort/platform_functions_ort.cc
+++ b/services/webnn/ort/platform_functions_ort.cc
@@ -68,6 +68,21 @@ PlatformFunctions* PlatformFunctions::GetInstance() {
   return instance.get();
 }
 
+const OrtDmlApi* PlatformFunctions::ort_dml_api() {
+  if (!ort_dml_api_.get()) {
+    const OrtDmlApi* ort_dml_api;
+    ort_api_->GetExecutionProviderApi(
+            "DML", ORT_API_VERSION,
+            reinterpret_cast<const void**>(&ort_dml_api));
+    if (!ort_dml_api) {
+      LOG(ERROR) << "[WebNN] Failed to get OrtDmlApi";
+      return nullptr;
+    }
+    ort_dml_api_ = ort_dml_api;
+  }
+  return ort_dml_api_.get();
+}
+
 bool PlatformFunctions::AllFunctionsLoaded() {
   return ort_get_api_base_proc_ && ort_api_ && ort_model_editor_api_;
 }

--- a/services/webnn/ort/platform_functions_ort.h
+++ b/services/webnn/ort/platform_functions_ort.h
@@ -11,6 +11,7 @@
 #include "base/no_destructor.h"
 #include "base/scoped_native_library.h"
 #include "third_party/onnxruntime_headers/src/include/onnxruntime/core/session/onnxruntime_c_api.h"
+#include "third_party/onnxruntime_headers/src/include/onnxruntime/core/providers/dml/dml_provider_factory.h"
 
 namespace webnn::ort {
 
@@ -26,6 +27,7 @@ class COMPONENT_EXPORT(WEBNN_SERVICE) PlatformFunctions {
     return ort_get_api_base_proc_;
   }
   const OrtApi* ort_api() const { return ort_api_.get(); }
+  const OrtDmlApi* ort_dml_api();
   const OrtModelEditorApi* ort_model_editor_api() const {
     return ort_model_editor_api_.get();
   }
@@ -41,6 +43,7 @@ class COMPONENT_EXPORT(WEBNN_SERVICE) PlatformFunctions {
   base::ScopedNativeLibrary ort_library_;
   OrtGetApiBaseProc ort_get_api_base_proc_ = nullptr;
   raw_ptr<const OrtApi> ort_api_ = nullptr;
+  raw_ptr<const OrtDmlApi> ort_dml_api_ = nullptr;
   raw_ptr<const OrtModelEditorApi> ort_model_editor_api_ = nullptr;
 };
 

--- a/services/webnn/ort/utils_ort.cc
+++ b/services/webnn/ort/utils_ort.cc
@@ -48,6 +48,12 @@ const OrtApi* GetOrtApi() {
   return platform_functions->ort_api();
 }
 
+const OrtDmlApi* GetOrtDmlApi() {
+  PlatformFunctions* platform_functions = PlatformFunctions::GetInstance();
+  CHECK(platform_functions);
+  return platform_functions->ort_dml_api(); 
+}
+
 const OrtModelEditorApi* GetOrtModelEditorApi() {
   PlatformFunctions* platform_functions = PlatformFunctions::GetInstance();
   CHECK(platform_functions);

--- a/services/webnn/ort/utils_ort.h
+++ b/services/webnn/ort/utils_ort.h
@@ -8,6 +8,7 @@
 #include "services/webnn/public/cpp/operand_descriptor.h"
 #include "services/webnn/public/mojom/webnn_error.mojom.h"
 #include "third_party/onnxruntime_headers/src/include/onnxruntime/core/session/onnxruntime_c_api.h"
+#include "third_party/onnxruntime_headers/src/include/onnxruntime/core/providers/dml/dml_provider_factory.h"
 
 namespace webnn::ort {
 
@@ -15,6 +16,8 @@ ONNXTensorElementDataType OperandTypeToONNXTensorElementDataType(
     OperandDataType data_type);
 
 const OrtApi* GetOrtApi();
+
+const OrtDmlApi* GetOrtDmlApi();
 
 const OrtModelEditorApi* GetOrtModelEditorApi();
 

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -35,6 +35,9 @@ inline constexpr char kWebNNUseOrt[] = "webnn-use-ort";
 // Usage: --no-sandbox --webnn-ort-dump-model=./OnnxModels
 inline constexpr char kWebNNOrtDumpModel[] = "webnn-ort-dump-model";
 
+// Use DirectML EP of ONNX Runtime
+inline constexpr char kWebNNOrtUseDml[] = "webnn-ort-use-dml";
+
 // Use OpenVINO EP of ONNX Runtime, WebNN device type will map OpenVINO device
 // type.
 inline constexpr char kWebNNOrtUseOpenvino[] = "webnn-ort-use-openvino";

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -36,7 +36,7 @@ inline constexpr char kWebNNUseOrt[] = "webnn-use-ort";
 inline constexpr char kWebNNOrtDumpModel[] = "webnn-ort-dump-model";
 
 // Use DirectML EP of ONNX Runtime
-inline constexpr char kWebNNOrtUseDml[] = "webnn-ort-use-dml";
+inline constexpr char kWebNNOrtUseDmlGpu[] = "webnn-ort-use-dml";
 
 // Use OpenVINO EP of ONNX Runtime, WebNN device type will map OpenVINO device
 // type.


### PR DESCRIPTION
Enable ort DML EP for workload test. 

Needs to build ort with `--use_dml` flag, and copy `DirectML.dll`, `onnxruntime_providers_shared.dll` and `onnxruntime.dll` into chromium build folder.