### PR TITLE
Remove 'output_shape' attribute from ConvTranspose

### DIFF
--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -1075,9 +1075,6 @@ GraphBuilderOrt::AddConv2dOperation(const mojom::Conv2d& conv2d) {
       std::array<int64_t, 2> output_size = {
           base::checked_cast<int64_t>(output_shape[2]),
           base::checked_cast<int64_t>(output_shape[3])};
-      attributes.push_back(
-          model_editor_.CreateAttribute(/*name=*/"output_shape", output_size));
-
       // According to the ONNX ConvTranspose2d documentation, the shape of the
       // output_padding is calculated as:
       // output_padding[i] = output_shape[i] - stride[i] * (input_size[i] - 1) -

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -1111,11 +1111,12 @@ GraphBuilderOrt::AddConv2dOperation(const mojom::Conv2d& conv2d) {
           output_padding_height.ValueOrDie(),
           output_padding_width.ValueOrDie()};
 
-      // According to the ONNX ConvTranspose2d documentation, since pads will be
-      // auto generated if output_shape is specified, and output_shape is
-      // determined by pads and output_padding, we need to calculate the actual
-      // output_padding to ensure that the pads value automatically calculated
-      // is correct.
+      // According to the ONNX ConvTranspose2d documentation, `output_padding`
+      // is a zero vector if not specified and `pads` will be auto generated if
+      // `output_shape` is specified. So we need to calculate the
+      // `output_padding` and explicitly set it to ensure that the attributes
+      // information is not missing. Since the `pads` attribute has already been
+      // set, there is no need to set `output_size` attribute.
       // https://onnx.ai/onnx/operators/onnx__ConvTranspose.html#attributes
       attributes.push_back(model_editor_.CreateAttribute(
           /*name=*/"output_padding", output_padding));


### PR DESCRIPTION
This PR resolves the crash issue for convTranspose2d WPT with `groups` attribute on NPU.
Fix issue [1504](https://github.com/otcshare/webnn-native/issues/1504).