### PR TITLE
Enable shape and type inference check

### DIFF
--- a/services/webnn/ort/context_impl_ort.cc
+++ b/services/webnn/ort/context_impl_ort.cc
@@ -111,9 +111,9 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
   }
 
   // Enable strict shape type inference check. All inconsistencies encountered
-  // will expose errors during session creation. For example, if the WebNN model
-  // has a reduce op with keepdims set to 0, but the ONNX model has keepdims set
-  // to 1, the session creation will fail due to inconsistent shape.
+  // will expose errors during session creation. For example, if the graph
+  // output shape set by WebNN is different from ONNX shape inference result,
+  // the session creation will fail.
   CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
       session_options.get(),
       /*config_key=*/kOrtSessionOptionsConfigStrictShapeTypeInference,

--- a/services/webnn/ort/context_impl_ort.cc
+++ b/services/webnn/ort/context_impl_ort.cc
@@ -110,6 +110,11 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
         /*config_value=*/"1"));
   }
 
+  CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
+      session_options.get(),
+      /*config_key=*/kOrtSessionOptionsConfigStrictShapeTypeInference,
+      /*config_value=*/"1"));
+
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
           switches::kWebNNOrtUseOpenvino)) {
     std::vector<const char*> provider_options_keys;

--- a/services/webnn/ort/context_impl_ort.cc
+++ b/services/webnn/ort/context_impl_ort.cc
@@ -111,7 +111,9 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
   }
 
   // Enable strict shape type inference check. All inconsistencies encountered
-  // will expose errors during session creation.
+  // will expose errors during session creation. For example, if the WebNN model
+  // has a reduce op with keepdims set to 0, but the ONNX model has keepdims set
+  // to 1, the session creation will fail due to inconsistent shape.
   CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
       session_options.get(),
       /*config_key=*/kOrtSessionOptionsConfigStrictShapeTypeInference,

--- a/services/webnn/ort/context_impl_ort.cc
+++ b/services/webnn/ort/context_impl_ort.cc
@@ -110,6 +110,8 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
         /*config_value=*/"1"));
   }
 
+  // Enable strict shape type inference check. All inconsistencies encountered
+  // will expose errors during session creation.
   CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
       session_options.get(),
       /*config_key=*/kOrtSessionOptionsConfigStrictShapeTypeInference,


### PR DESCRIPTION
Enable shape and type inference check during session creation stage, otherwise, mismatch will expose error during session run stage which is too late.