### PR TITLE
initialize ort tensor with zeros

### DIFF
--- a/services/webnn/ort/tensor_impl_ort.cc
+++ b/services/webnn/ort/tensor_impl_ort.cc
@@ -4,6 +4,8 @@
 
 #include "services/webnn/ort/tensor_impl_ort.h"
 
+#include <cstring>
+
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
 #include "services/webnn/ort/context_impl_ort.h"
 #include "services/webnn/ort/error_ort.h"
@@ -48,6 +50,15 @@ TensorImplOrt::Create(
                                               "Failed to create tensor."));
   }
   CHECK(tensor.get());
+
+  // Initialize the tensor with zeros, otherwise, reading uninitialized memory
+  // will get random values.
+  void* ort_tensor_raw_data = nullptr;
+  CHECK_STATUS(
+      GetOrtApi()->GetTensorMutableData(tensor.get(), &ort_tensor_raw_data));
+  CHECK(ort_tensor_raw_data);
+  size_t tensor_size = tensor_info->descriptor.PackedByteLength();
+  std::memset(ort_tensor_raw_data, 0, tensor_size);
 
   auto buffer_content = std::make_unique<BufferContentOrt>(std::move(tensor));
   auto buffer_state =


### PR DESCRIPTION
Fix that reading uninitialized ort tensors will get random values: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/external/wpt/webnn/conformance_tests/tensor.https.any.js;l=372?q=tensor.https.any.js
 