### PR TITLE
Move some WebNN ORT switches to mojom features and about:flags

### DIFF
--- a/chrome/browser/BUILD.gn
+++ b/chrome/browser/BUILD.gn
@@ -2487,6 +2487,7 @@ static_library("browser") {
     "//services/shape_detection/public/mojom",
     "//services/strings",
     "//services/video_effects/buildflags",
+    "//services/webnn:buildflags",
     "//services/webnn/public/mojom",
     "//skia",
     "//sql",

--- a/chrome/browser/DEPS
+++ b/chrome/browser/DEPS
@@ -499,6 +499,7 @@ include_rules = [
   "+services/video_effects/test",
   "+services/viz/public",
   "+services/viz/privileged",
+  "+services/webnn/buildflags.h",
   "+skia/buildflags.h",
   "+skia/ext",
   "+third_party/boringssl/src/include",

--- a/chrome/browser/about_flags.cc
+++ b/chrome/browser/about_flags.cc
@@ -226,6 +226,7 @@
 #include "services/network/public/cpp/features.h"
 #include "services/network/public/cpp/network_switches.h"
 #include "services/tracing/public/cpp/tracing_features.h"
+#include "services/webnn/buildflags.h"
 #include "services/webnn/public/mojom/features.mojom-features.h"
 #include "skia/buildflags.h"
 #include "storage/browser/quota/quota_features.h"
@@ -8360,6 +8361,20 @@ const FeatureEntry kFeatureEntries[] = {
      kOsAll,
      FEATURE_VALUE_TYPE(
          webnn::mojom::features::kExperimentalWebMachineLearningNeuralNetwork)},
+
+#if BUILDFLAG(WEBNN_USE_ORT)
+    {"webnn-ort", flag_descriptions::kWebNNOrtName,
+     flag_descriptions::kWebNNOrtDescription, kOsWin,
+     FEATURE_VALUE_TYPE(webnn::mojom::features::kWebNNOrt)},
+
+    {"webnn-ort-openvino", flag_descriptions::kWebNNOrtOpenVinoName,
+     flag_descriptions::kWebNNOrtOpenVinoDescription, kOsWin,
+     FEATURE_VALUE_TYPE(webnn::mojom::features::kWebNNOrtOpenVino)},
+
+    {"webnn-ort-cpu-fallback", flag_descriptions::kWebNNOrtCpuFallbackName,
+     flag_descriptions::kWebNNOrtCpuFallbackDescription, kOsWin,
+     FEATURE_VALUE_TYPE(webnn::mojom::features::kWebNNOrtCpuFallback)},
+#endif  // BUILDFLAG(WEBNN_USE_ORT)
 
 #if BUILDFLAG(IS_MAC)
     {"webnn-coreml", flag_descriptions::kWebNNCoreMLName,

--- a/chrome/browser/flag-metadata.json
+++ b/chrome/browser/flag-metadata.json
@@ -9404,6 +9404,21 @@
     "expiry_milestone": 146
   },
   {
+    "name": "webnn-ort",
+    "owners": [ "reillyg@chromium.org", "rafael.cintron@microsoft.com" ],
+    "expiry_milestone": 146
+  },
+  {
+    "name": "webnn-ort-cpu-fallback",
+    "owners": [ "reillyg@chromium.org", "rafael.cintron@microsoft.com" ],
+    "expiry_milestone": 146
+  },
+  {
+    "name": "webnn-ort-openvino",
+    "owners": [ "reillyg@chromium.org", "rafael.cintron@microsoft.com" ],
+    "expiry_milestone": 146
+  },
+  {
     "name": "webpage-alternative-text-zoom",
     "owners": [ "rkgibson@google.com", "bling-flags@google.com" ],
     "expiry_milestone": 127

--- a/chrome/browser/flag_descriptions.cc
+++ b/chrome/browser/flag_descriptions.cc
@@ -2537,6 +2537,27 @@ const char kWebNNDirectMLDescription[] =
     "NPU inference with the WebNN API. Disabling this flag enables a "
     "fallback to TFLite.";
 
+#if BUILDFLAG(WEBNN_USE_ORT)
+const char kWebNNOrtName[] = "ONNX Runtime backend for WebNN";
+const char kWebNNOrtDescription[] =
+    "Enables using ONNX Runtime for inference with the WebNN API. Runs on CPU "
+    "EP by default.";
+
+const char kWebNNOrtCpuFallbackName[] =
+    "Enables CPU fallback for ONNX Runtime backend for WebNN";
+const char kWebNNOrtCpuFallbackDescription[] =
+    "Allows ONNX Runtime OpenVINO EP falling back to CPU. Disabling this flag "
+    "leads to graph building failure when there is fallback for GPU or NPU "
+    "inference.";
+
+const char kWebNNOrtOpenVinoName[] =
+    "ONNX Runtime backend OpenVINO EP for WebNN";
+const char kWebNNOrtOpenVinoDescription[] =
+    "Enables using ONNX Runtime OpenVINO EP for CPU, GPU and NPU inference "
+    "with the WebNN API. Requires the \"ONNX Runtime backend for WebNN\" flag "
+    "to be enabled.";
+#endif  // BUILDFLAG(WEBNN_USE_ORT)
+
 const char kSystemProxyForSystemServicesName[] =
     "Enable system-proxy for selected system services";
 const char kSystemProxyForSystemServicesDescription[] =

--- a/chrome/browser/flag_descriptions.h
+++ b/chrome/browser/flag_descriptions.h
@@ -22,6 +22,7 @@
 #include "net/net_buildflags.h"
 #include "pdf/buildflags.h"
 #include "printing/buildflags/buildflags.h"
+#include "services/webnn/buildflags.h"
 #include "skia/buildflags.h"
 #include "third_party/blink/public/common/buildflags.h"
 
@@ -1454,6 +1455,17 @@ extern const char kWebNNCoreMLDescription[];
 
 extern const char kWebNNDirectMLName[];
 extern const char kWebNNDirectMLDescription[];
+
+#if BUILDFLAG(WEBNN_USE_ORT)
+extern const char kWebNNOrtName[];
+extern const char kWebNNOrtDescription[];
+
+extern const char kWebNNOrtCpuFallbackName[];
+extern const char kWebNNOrtCpuFallbackDescription[];
+
+extern const char kWebNNOrtOpenVinoName[];
+extern const char kWebNNOrtOpenVinoDescription[];
+#endif  // BUILDFLAG(WEBNN_USE_ORT)
 
 #if BUILDFLAG(IS_ANDROID)
 extern const char kNewEtc1EncoderName[];

--- a/content/browser/gpu/gpu_process_host.cc
+++ b/content/browser/gpu/gpu_process_host.cc
@@ -328,11 +328,8 @@ static const char* const kSwitchNames[] = {
     switches::kWebNNTfliteDumpModel,
 #endif
 #if BUILDFLAG(WEBNN_USE_ORT)
-    switches::kWebNNUseOrt,
     switches::kWebNNOrtDumpModel,
     switches::kWebNNOrtUseDmlGpu,
-    switches::kWebNNOrtUseOpenvino,
-    switches::kWebNNOrtDisableCpuFallback,
     switches::kWebNNOrtOVGpuPrecision,
     switches::kWebNNOrtUseOVModelCache,
 #endif

--- a/services/webnn/ort/context_impl_ort.cc
+++ b/services/webnn/ort/context_impl_ort.cc
@@ -17,6 +17,7 @@
 #include "services/webnn/ort/utils_ort.h"
 #include "services/webnn/public/cpp/supported_data_types.h"
 #include "services/webnn/public/cpp/webnn_trace.h"
+#include "services/webnn/public/mojom/features.mojom.h"
 #include "services/webnn/public/mojom/webnn_context_provider.mojom.h"
 #include "services/webnn/public/mojom/webnn_graph.mojom.h"
 #include "services/webnn/public/mojom/webnn_tensor.mojom.h"
@@ -80,8 +81,7 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
     base::FilePath dump_path = dump_directory.AppendASCII(
         base::StringPrintf("model%d.onnx", dump_count++));
 
-    if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
-            switches::kWebNNOrtUseOpenvino)) {
+    if (!base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino)) {
       CALL_ORT_FUNC(ort_api->SetOptimizedModelFilePath(
           session_options.get(), dump_path.value().c_str()));
     } else {
@@ -102,8 +102,8 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
     // supports it.
   }
 
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kWebNNOrtDisableCpuFallback)) {
+  if (!base::FeatureList::IsEnabled(mojom::features::kWebNNOrtCpuFallback) &&
+      base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino)) {
     CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
         session_options.get(),
         /*config_key=*/kOrtSessionOptionsDisableCPUEPFallback,
@@ -119,8 +119,7 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
       /*config_key=*/kOrtSessionOptionsConfigStrictShapeTypeInference,
       /*config_value=*/"1"));
 
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kWebNNOrtUseOpenvino)) {
+  if (base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino)) {
     std::vector<const char*> provider_options_keys;
     std::vector<const char*> provider_options_values;
     std::string gpu_precision;

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -19,6 +19,7 @@
 #include "services/webnn/ort/utils_ort.h"
 #include "services/webnn/public/cpp/graph_validation_utils.h"
 #include "services/webnn/public/cpp/supported_data_types.h"
+#include "services/webnn/public/mojom/features.mojom.h"
 #include "services/webnn/webnn_constant_operand.h"
 #include "services/webnn/webnn_switches.h"
 #include "third_party/fp16/src/include/fp16.h"
@@ -357,8 +358,7 @@ base::expected<std::string, mojom::ErrorPtr> GraphBuilderOrt::CreateInitializer(
   ScopedOrtStatus status;
   // TODO(https://github.com/shiyi9801/chromium/issues/70): Remove this
   // workaround for OpenVINO EP once the invalid external data issue is fixed.
-  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kWebNNOrtUseOpenvino)) {
+  if (!base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino)) {
     status = model_editor_.AddInitializer(name, int64_shape, byte_span,
                                           TensorTypeMap<DataType>::value);
 
@@ -659,8 +659,7 @@ GraphBuilderOrt::AddInitializer(uint64_t constant_id) {
   ScopedOrtStatus status;
   // TODO(https://github.com/shiyi9801/chromium/issues/70): Remove this
   // workaround for OpenVINO EP once the invalid external data issue is fixed.
-  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kWebNNOrtUseOpenvino)) {
+  if (!base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino)) {
     status = model_editor_.AddInitializer(name, int64_shape, operand.ByteSpan(),
                                           onnx_data_type);
   } else {
@@ -1437,8 +1436,7 @@ GraphBuilderOrt::AddDequantizeOrQuantizeLinearOperation(
 
     // Currently, OpenVINO only supports axis == 0 when scale.size == 2.
     // https://github.com/openvinotoolkit/openvino/blob/master/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp#L228.
-    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-            switches::kWebNNOrtUseOpenvino) &&
+    if (base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino) &&
         std::is_same_v<DequantizeOrQuantizeLinear, mojom::DequantizeLinear>) {
       if (scale_shape.size() != 2) {
         // https://github.com/openvinotoolkit/openvino/blob/master/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp#L220

--- a/services/webnn/public/mojom/BUILD.gn
+++ b/services/webnn/public/mojom/BUILD.gn
@@ -3,8 +3,13 @@
 # found in the LICENSE file.
 
 import("//mojo/public/tools/bindings/mojom.gni")
+import("//services/webnn/features.gni")
 
 mojom_component("mojom") {
+  if (webnn_use_ort) {
+    enabled_features = [ "webnn_use_ort" ]
+  }
+
   output_prefix = "webnn_mojom"
   macro_prefix = "WEBNN_MOJOM"
 

--- a/services/webnn/public/mojom/features.mojom
+++ b/services/webnn/public/mojom/features.mojom
@@ -30,3 +30,26 @@ feature kWebNNDirectML {
   const string name = "WebNNDirectML";
   const bool default_state = true;
 };
+
+// Enables the ONNX Runtime backend for WebNN.
+[EnableIf=webnn_use_ort]
+feature kWebNNOrt {
+  const string name = "WebNNOrt";
+  const bool default_state = false;
+};
+
+// Allows the ONNX Runtime OpenVINO EP falling back to CPU for WebNN. When it's
+// set to false, ORT backend won't fall back to either default CPU EP or
+// OpenVINO EP CPU Plugin if graph build fails for GPU or NPU.
+[EnableIf=webnn_use_ort]
+feature kWebNNOrtCpuFallback {
+  const string name = "WebNNOrtCpuFallback";
+  const bool default_state = true;
+};
+
+// Enables the OpenVINO EP for ONNX Runtime backend for WebNN.
+[EnableIf=webnn_use_ort]
+feature kWebNNOrtOpenVino {
+  const string name = "WebNNOrtOpenVino";
+  const bool default_state = false;
+};

--- a/services/webnn/webnn_context_provider_impl.cc
+++ b/services/webnn/webnn_context_provider_impl.cc
@@ -244,8 +244,7 @@ void WebNNContextProviderImpl::CreateWebNNContext(
   RecordDeviceType(options->device);
 
 #if BUILDFLAG(WEBNN_USE_ORT)
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kWebNNUseOrt)) {
+  if (base::FeatureList::IsEnabled(mojom::features::kWebNNOrt)) {
     auto* platform_functions = ort::PlatformFunctions::GetInstance();
     if (!platform_functions) {
       std::move(callback).Run(ToError<mojom::CreateContextResult>(

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -27,8 +27,6 @@ inline constexpr char kWebNNTfliteDumpModel[] = "webnn-tflite-dump-model";
 #endif  // BUILDFLAG(WEBNN_USE_TFLITE)
 
 #if BUILDFLAG(WEBNN_USE_ORT)
-inline constexpr char kWebNNUseOrt[] = "webnn-use-ort";
-
 // Save the generated ONNX model file to the folder specified by
 // --webnn-ort-dump-model. Note, the folder needs to be accessible from the
 // GPU process sandbox or --no-sandbox must be used.
@@ -37,14 +35,6 @@ inline constexpr char kWebNNOrtDumpModel[] = "webnn-ort-dump-model";
 
 // Use DirectML EP of ONNX Runtime
 inline constexpr char kWebNNOrtUseDmlGpu[] = "webnn-ort-use-dml";
-
-// Use OpenVINO EP of ONNX Runtime, WebNN device type will map OpenVINO device
-// type.
-inline constexpr char kWebNNOrtUseOpenvino[] = "webnn-ort-use-openvino";
-
-// Disable CPU fallback for OpenVINO EP.
-inline constexpr char kWebNNOrtDisableCpuFallback[] =
-    "webnn-ort-disable-cpu-fallback";
 
 // For GPU, OV EP will use FP16 inference precision by default. You can specify
 // the flag to use FP32 or ACCURACY to get better accuracy, but it may result in


### PR DESCRIPTION
Three switches `--webnn-use-ort`, `--webnn-ort-use-openvino` and `--webnn-ort-disable-cpu-fallback` are moved to about:flags.

To enable the ORT backend, use `--enable-features=WebNNOrt`;
To enable the OV EP, use `--enable-features=WebNNOrtOpenVino`;
To disable the CPU fallback, use `--disable-features=WebNNOrtCpuFallback`.

Besides the switches in command line, you can also enable or disable these features in about:flags.

Fix #202
Fix #178