### PR TITLE
Add webnn:buildflags into gpu_ipc_service build deps

### DIFF
--- a/gpu/ipc/service/BUILD.gn
+++ b/gpu/ipc/service/BUILD.gn
@@ -89,6 +89,7 @@ component("service") {
     "//gpu/config",
     "//gpu/vulkan:buildflags",
     "//mojo/public/cpp/bindings",
+    "//services/webnn:buildflags",
     "//ui/base:ozone_buildflags",
   ]
   libs = []


### PR DESCRIPTION
Fix the build issue of gpu_init.cc which includes "services/webnn/buildflags.h" 
and checks BUILDFLAG(WEBNN_USE_ORT).