### PR TITLE
Support ifgo layout for lstm and lstmCell

### DIFF
--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -130,9 +130,6 @@ constexpr char kOpTypeWhere[] = "Where";
 constexpr char kInserted[] = "Inserted";
 constexpr char kUnderscore[] = "_";
 
-constexpr std::array<uint32_t, 3> kRznToZrnPermutation = {1, 0, 2};
-constexpr std::array<uint32_t, 4> kIfgoToIofgPermutation = {0, 3, 1, 2};
-
 base::unexpected<mojom::ErrorPtr> NewNotSupportedError(std::string message) {
   return base::unexpected(mojom::Error::New(
       mojom::Error::Code::kNotSupportedError, std::move(message)));
@@ -1773,6 +1770,7 @@ GraphBuilderOrt::AddGruOperation(const GruType& gru) {
         PrependReshape(recurrent_weight, {1, recurrent_weight_shape[0],
                                           recurrent_weight_shape[1]}));
   }
+  const std::array<uint32_t, 3> kRznToZrnPermutation = {1, 0, 2};
   if (gru.layout == mojom::GruWeightLayout::kRzn) {
     weight = TransposeRnnWeightOrBiasLayout(weight, kRznToZrnPermutation);
     recurrent_weight =
@@ -2270,6 +2268,7 @@ GraphBuilderOrt::AddLstmOperation(const LstmType& lstm) {
         PrependReshape(recurrent_weight, {1, recurrent_weight_shape[0],
                                           recurrent_weight_shape[1]}));
   }
+  const std::array<uint32_t, 4> kIfgoToIofgPermutation = {0, 3, 1, 2};
   if (lstm.layout == mojom::LstmWeightLayout::kIfgo) {
     weight = TransposeRnnWeightOrBiasLayout(weight, kIfgoToIofgPermutation);
     recurrent_weight = TransposeRnnWeightOrBiasLayout(recurrent_weight,

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -339,13 +339,20 @@ GraphBuilderOrt::CreateOrReshapeBias(const std::optional<uint32_t>& bias_id,
 }
 
 [[nodiscard]] base::expected<std::string, mojom::ErrorPtr>
-GraphBuilderOrt::ConvertRnnGateLayout(std::string_view weight_or_bias,
-                                      uint32_t num_gates) {
-  // Use Split operator to split the weight/bias into num_gates slices.
+GraphBuilderOrt::TransposeRnnWeightOrBiasLayout(
+    std::string_view weight_or_bias,
+    base::span<const uint32_t> permutation) {
+  size_t num_gates = permutation.size();
   // GRU: (update, reset, and new gates, num_gates = 3).
   // LSTM: (input, output, forget and cell gates, num_gates = 4).
+  if (num_gates != 3 && num_gates != 4) {
+    return NewNotSupportedError(
+        "[WebNN] Unsupported number of gates for RNN operators.");
+  }
+
+  // Use Split operator to split the weight/bias into num_gates slices.
   std::vector<std::string> gate_names;
-  for (uint32_t i = 0; i < num_gates; i++) {
+  for (size_t i = 0; i < num_gates; i++) {
     gate_names.push_back(GenerateNextOperandName());
   }
   std::vector<ScopedOrtOpAttr> split_attrs;
@@ -364,19 +371,9 @@ GraphBuilderOrt::ConvertRnnGateLayout(std::string_view weight_or_bias,
                         split_inputs, split_outputs, std::move(split_attrs));
 
   // Use Concat operator to concatenate the slices in the order of permutation.
-  std::vector<uint32_t> perm;
-  if (num_gates == 3) {
-    // GRU: RZN -> ZRN (R:0 Z:1 N:2 -> Z:1 R:0 N:2)
-    perm = {1, 0, 2};
-  } else if (num_gates == 4) {
-    // LSTM: IFGO -> IOFG (I:0 F:1 G:2 O:3 -> I:0 O:3 F:1 G:2)
-    perm = {0, 3, 1, 2};
-  } else {
-    NOTREACHED() << "[WebNN] Unsupported number of gates for RNN operators.";
-  }
   std::vector<const char*> concat_inputs;
   concat_inputs.reserve(num_gates);
-  for (uint32_t idx : perm) {
+  for (uint32_t idx : permutation) {
     concat_inputs.push_back(gate_names[idx].c_str());
   }
   std::string new_weight_or_bias = GenerateNextOperandName();
@@ -1781,9 +1778,9 @@ GraphBuilderOrt::AddGruOperation(const GruType& gru) {
                                           recurrent_weight_shape[1]}));
   }
   if (gru.layout == mojom::GruWeightLayout::kRzn) {
-    ASSIGN_OR_RETURN(weight, ConvertRnnGateLayout(weight, 3));
-    ASSIGN_OR_RETURN(recurrent_weight,
-                     ConvertRnnGateLayout(recurrent_weight, 3));
+    ASSIGN_OR_RETURN(weight, TransposeRnnWeightOrBiasLayout(weight, {1, 0, 2}));
+    ASSIGN_OR_RETURN(recurrent_weight, TransposeRnnWeightOrBiasLayout(
+                                           recurrent_weight, {1, 0, 2}));
   }
   std::vector<const char*> inputs = {input.c_str(), weight.c_str(),
                                      recurrent_weight.c_str()};
@@ -1814,8 +1811,9 @@ GraphBuilderOrt::AddGruOperation(const GruType& gru) {
                      CreateOrReshapeBias(gru.recurrent_bias_operand_id,
                                          input_data_type, bias_dims));
     if (gru.layout == mojom::GruWeightLayout::kRzn) {
-      ASSIGN_OR_RETURN(bias, ConvertRnnGateLayout(bias, 3));
-      ASSIGN_OR_RETURN(recurrent_bias, ConvertRnnGateLayout(recurrent_bias, 3));
+      ASSIGN_OR_RETURN(bias, TransposeRnnWeightOrBiasLayout(bias, {1, 0, 2}));
+      ASSIGN_OR_RETURN(recurrent_bias, TransposeRnnWeightOrBiasLayout(
+                                           recurrent_bias, {1, 0, 2}));
     }
     // Concat bias and recurrent_bias
     concatenated_bias = GenerateNextOperandName();
@@ -2277,9 +2275,10 @@ GraphBuilderOrt::AddLstmOperation(const LstmType& lstm) {
                                           recurrent_weight_shape[1]}));
   }
   if (lstm.layout == mojom::LstmWeightLayout::kIfgo) {
-    ASSIGN_OR_RETURN(weight, ConvertRnnGateLayout(weight, 4));
-    ASSIGN_OR_RETURN(recurrent_weight,
-                     ConvertRnnGateLayout(recurrent_weight, 4));
+    ASSIGN_OR_RETURN(weight,
+                     TransposeRnnWeightOrBiasLayout(weight, {0, 3, 1, 2}));
+    ASSIGN_OR_RETURN(recurrent_weight, TransposeRnnWeightOrBiasLayout(
+                                           recurrent_weight, {0, 3, 1, 2}));
   }
   std::vector<const char*> inputs = {input.c_str(), weight.c_str(),
                                      recurrent_weight.c_str()};
@@ -2309,8 +2308,10 @@ GraphBuilderOrt::AddLstmOperation(const LstmType& lstm) {
                      CreateOrReshapeBias(lstm.recurrent_bias_operand_id,
                                          input_data_type, bias_dims));
     if (lstm.layout == mojom::LstmWeightLayout::kIfgo) {
-      ASSIGN_OR_RETURN(bias, ConvertRnnGateLayout(bias, 4));
-      ASSIGN_OR_RETURN(recurrent_bias, ConvertRnnGateLayout(recurrent_bias, 4));
+      ASSIGN_OR_RETURN(bias,
+                       TransposeRnnWeightOrBiasLayout(bias, {0, 3, 1, 2}));
+      ASSIGN_OR_RETURN(recurrent_bias, TransposeRnnWeightOrBiasLayout(
+                                           recurrent_bias, {0, 3, 1, 2}));
     }
     // Concat bias and recurrent_bias
     concatenated_bias = GenerateNextOperandName();

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -130,6 +130,9 @@ constexpr char kOpTypeWhere[] = "Where";
 constexpr char kInserted[] = "Inserted";
 constexpr char kUnderscore[] = "_";
 
+constexpr std::array<uint32_t, 3> kRznToZrnPermutation = {1, 0, 2};
+constexpr std::array<uint32_t, 4> kIfgoToIofgPermutation = {0, 3, 1, 2};
+
 base::unexpected<mojom::ErrorPtr> NewNotSupportedError(std::string message) {
   return base::unexpected(mojom::Error::New(
       mojom::Error::Code::kNotSupportedError, std::move(message)));
@@ -338,17 +341,10 @@ GraphBuilderOrt::CreateOrReshapeBias(const std::optional<uint32_t>& bias_id,
   return bias;
 }
 
-[[nodiscard]] base::expected<std::string, mojom::ErrorPtr>
-GraphBuilderOrt::TransposeRnnWeightOrBiasLayout(
+std::string GraphBuilderOrt::TransposeRnnWeightOrBiasLayout(
     std::string_view weight_or_bias,
     base::span<const uint32_t> permutation) {
   size_t num_gates = permutation.size();
-  // GRU: (update, reset, and new gates, num_gates = 3).
-  // LSTM: (input, output, forget and cell gates, num_gates = 4).
-  if (num_gates != 3 && num_gates != 4) {
-    return NewNotSupportedError(
-        "[WebNN] Unsupported number of gates for RNN operators.");
-  }
 
   // Use Split operator to split the weight/bias into num_gates slices.
   std::vector<std::string> gate_names;
@@ -1778,9 +1774,9 @@ GraphBuilderOrt::AddGruOperation(const GruType& gru) {
                                           recurrent_weight_shape[1]}));
   }
   if (gru.layout == mojom::GruWeightLayout::kRzn) {
-    ASSIGN_OR_RETURN(weight, TransposeRnnWeightOrBiasLayout(weight, {1, 0, 2}));
-    ASSIGN_OR_RETURN(recurrent_weight, TransposeRnnWeightOrBiasLayout(
-                                           recurrent_weight, {1, 0, 2}));
+    weight = TransposeRnnWeightOrBiasLayout(weight, kRznToZrnPermutation);
+    recurrent_weight =
+        TransposeRnnWeightOrBiasLayout(recurrent_weight, kRznToZrnPermutation);
   }
   std::vector<const char*> inputs = {input.c_str(), weight.c_str(),
                                      recurrent_weight.c_str()};
@@ -1811,9 +1807,9 @@ GraphBuilderOrt::AddGruOperation(const GruType& gru) {
                      CreateOrReshapeBias(gru.recurrent_bias_operand_id,
                                          input_data_type, bias_dims));
     if (gru.layout == mojom::GruWeightLayout::kRzn) {
-      ASSIGN_OR_RETURN(bias, TransposeRnnWeightOrBiasLayout(bias, {1, 0, 2}));
-      ASSIGN_OR_RETURN(recurrent_bias, TransposeRnnWeightOrBiasLayout(
-                                           recurrent_bias, {1, 0, 2}));
+      bias = TransposeRnnWeightOrBiasLayout(bias, kRznToZrnPermutation);
+      recurrent_bias =
+          TransposeRnnWeightOrBiasLayout(recurrent_bias, kRznToZrnPermutation);
     }
     // Concat bias and recurrent_bias
     concatenated_bias = GenerateNextOperandName();
@@ -2275,10 +2271,9 @@ GraphBuilderOrt::AddLstmOperation(const LstmType& lstm) {
                                           recurrent_weight_shape[1]}));
   }
   if (lstm.layout == mojom::LstmWeightLayout::kIfgo) {
-    ASSIGN_OR_RETURN(weight,
-                     TransposeRnnWeightOrBiasLayout(weight, {0, 3, 1, 2}));
-    ASSIGN_OR_RETURN(recurrent_weight, TransposeRnnWeightOrBiasLayout(
-                                           recurrent_weight, {0, 3, 1, 2}));
+    weight = TransposeRnnWeightOrBiasLayout(weight, kIfgoToIofgPermutation);
+    recurrent_weight = TransposeRnnWeightOrBiasLayout(recurrent_weight,
+                                                      kIfgoToIofgPermutation);
   }
   std::vector<const char*> inputs = {input.c_str(), weight.c_str(),
                                      recurrent_weight.c_str()};
@@ -2308,10 +2303,9 @@ GraphBuilderOrt::AddLstmOperation(const LstmType& lstm) {
                      CreateOrReshapeBias(lstm.recurrent_bias_operand_id,
                                          input_data_type, bias_dims));
     if (lstm.layout == mojom::LstmWeightLayout::kIfgo) {
-      ASSIGN_OR_RETURN(bias,
-                       TransposeRnnWeightOrBiasLayout(bias, {0, 3, 1, 2}));
-      ASSIGN_OR_RETURN(recurrent_bias, TransposeRnnWeightOrBiasLayout(
-                                           recurrent_bias, {0, 3, 1, 2}));
+      bias = TransposeRnnWeightOrBiasLayout(bias, kIfgoToIofgPermutation);
+      recurrent_bias = TransposeRnnWeightOrBiasLayout(recurrent_bias,
+                                                      kIfgoToIofgPermutation);
     }
     // Concat bias and recurrent_bias
     concatenated_bias = GenerateNextOperandName();

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -338,31 +338,52 @@ GraphBuilderOrt::CreateOrReshapeBias(const std::optional<uint32_t>& bias_id,
   return bias;
 }
 
-std::string GraphBuilderOrt::ConvertRznToZrn(std::string_view weight_or_bias) {
-  // Use Split operator to split the weight/bias into 3 (r, z, n) slices.
-  std::string r_gate = GenerateNextOperandName();
-  std::string z_gate = GenerateNextOperandName();
-  std::string n_gate = GenerateNextOperandName();
+[[nodiscard]] base::expected<std::string, mojom::ErrorPtr>
+GraphBuilderOrt::ConvertRnnGateLayout(std::string_view weight_or_bias,
+                                      uint32_t num_gates) {
+  // Use Split operator to split the weight/bias into num_gates slices.
+  // GRU: (update, reset, and new gates, num_gates = 3).
+  // LSTM: (input, output, forget and cell gates, num_gates = 4).
+  std::vector<std::string> gate_names;
+  for (uint32_t i = 0; i < num_gates; i++) {
+    gate_names.push_back(GenerateNextOperandName());
+  }
   std::vector<ScopedOrtOpAttr> split_attrs;
   split_attrs.reserve(2);
   split_attrs.push_back(
       model_editor_.CreateAttribute("axis", static_cast<int64_t>(1)));
-  split_attrs.push_back(
-      model_editor_.CreateAttribute("num_outputs", static_cast<int64_t>(3)));
+  split_attrs.push_back(model_editor_.CreateAttribute(
+      "num_outputs", static_cast<int64_t>(num_gates)));
   std::array<const char*, 1> split_inputs = {weight_or_bias.data()};
-  std::array<const char*, 3> split_outputs = {r_gate.c_str(), z_gate.c_str(),
-                                              n_gate.c_str()};
+  std::vector<const char*> split_outputs;
+  split_outputs.reserve(num_gates);
+  for (const auto& gate : gate_names) {
+    split_outputs.push_back(gate.c_str());
+  }
   model_editor_.AddNode(kOpTypeSplit, GenerateNextOperationName("split"),
                         split_inputs, split_outputs, std::move(split_attrs));
 
-  // Use Concat operator to concatenate the slices in the order of z, r, n.
+  // Use Concat operator to concatenate the slices in the order of permutation.
+  std::vector<uint32_t> perm;
+  if (num_gates == 3) {
+    // GRU: RZN -> ZRN (R:0 Z:1 N:2 -> Z:1 R:0 N:2)
+    perm = {1, 0, 2};
+  } else if (num_gates == 4) {
+    // LSTM: IFGO -> IOFG (I:0 F:1 G:2 O:3 -> I:0 O:3 F:1 G:2)
+    perm = {0, 3, 1, 2};
+  } else {
+    NOTREACHED() << "[WebNN] Unsupported number of gates for RNN operators.";
+  }
+  std::vector<const char*> concat_inputs;
+  concat_inputs.reserve(num_gates);
+  for (uint32_t idx : perm) {
+    concat_inputs.push_back(gate_names[idx].c_str());
+  }
   std::string new_weight_or_bias = GenerateNextOperandName();
   std::vector<ScopedOrtOpAttr> concat_attrs;
   concat_attrs.reserve(1);
   concat_attrs.push_back(
       model_editor_.CreateAttribute("axis", static_cast<int64_t>(1)));
-  std::array<const char*, 3> concat_inputs = {z_gate.c_str(), r_gate.c_str(),
-                                              n_gate.c_str()};
   std::array<const char*, 1> concat_outputs = {new_weight_or_bias.c_str()};
   model_editor_.AddNode(kOpTypeConcat, GenerateNextOperationName("concat"),
                         concat_inputs, concat_outputs, std::move(concat_attrs));
@@ -1760,8 +1781,9 @@ GraphBuilderOrt::AddGruOperation(const GruType& gru) {
                                           recurrent_weight_shape[1]}));
   }
   if (gru.layout == mojom::GruWeightLayout::kRzn) {
-    weight = ConvertRznToZrn(weight);
-    recurrent_weight = ConvertRznToZrn(recurrent_weight);
+    ASSIGN_OR_RETURN(weight, ConvertRnnGateLayout(weight, 3));
+    ASSIGN_OR_RETURN(recurrent_weight,
+                     ConvertRnnGateLayout(recurrent_weight, 3));
   }
   std::vector<const char*> inputs = {input.c_str(), weight.c_str(),
                                      recurrent_weight.c_str()};
@@ -1791,10 +1813,9 @@ GraphBuilderOrt::AddGruOperation(const GruType& gru) {
     ASSIGN_OR_RETURN(std::string recurrent_bias,
                      CreateOrReshapeBias(gru.recurrent_bias_operand_id,
                                          input_data_type, bias_dims));
-
     if (gru.layout == mojom::GruWeightLayout::kRzn) {
-      bias = ConvertRznToZrn(bias);
-      recurrent_bias = ConvertRznToZrn(recurrent_bias);
+      ASSIGN_OR_RETURN(bias, ConvertRnnGateLayout(bias, 3));
+      ASSIGN_OR_RETURN(recurrent_bias, ConvertRnnGateLayout(recurrent_bias, 3));
     }
     // Concat bias and recurrent_bias
     concatenated_bias = GenerateNextOperandName();
@@ -2255,6 +2276,11 @@ GraphBuilderOrt::AddLstmOperation(const LstmType& lstm) {
         PrependReshape(recurrent_weight, {1, recurrent_weight_shape[0],
                                           recurrent_weight_shape[1]}));
   }
+  if (lstm.layout == mojom::LstmWeightLayout::kIfgo) {
+    ASSIGN_OR_RETURN(weight, ConvertRnnGateLayout(weight, 4));
+    ASSIGN_OR_RETURN(recurrent_weight,
+                     ConvertRnnGateLayout(recurrent_weight, 4));
+  }
   std::vector<const char*> inputs = {input.c_str(), weight.c_str(),
                                      recurrent_weight.c_str()};
   uint32_t num_directions = 1;
@@ -2277,11 +2303,15 @@ GraphBuilderOrt::AddLstmOperation(const LstmType& lstm) {
     const OperandDataType input_data_type =
         GetOperand(lstm.input_operand_id).descriptor.data_type();
     ASSIGN_OR_RETURN(
-        const std::string bias,
+        std::string bias,
         CreateOrReshapeBias(lstm.bias_operand_id, input_data_type, bias_dims));
-    ASSIGN_OR_RETURN(const std::string recurrent_bias,
+    ASSIGN_OR_RETURN(std::string recurrent_bias,
                      CreateOrReshapeBias(lstm.recurrent_bias_operand_id,
                                          input_data_type, bias_dims));
+    if (lstm.layout == mojom::LstmWeightLayout::kIfgo) {
+      ASSIGN_OR_RETURN(bias, ConvertRnnGateLayout(bias, 4));
+      ASSIGN_OR_RETURN(recurrent_bias, ConvertRnnGateLayout(recurrent_bias, 4));
+    }
     // Concat bias and recurrent_bias
     concatenated_bias = GenerateNextOperandName();
     std::array<const char*, 2> bias_inputs = {bias.c_str(),
@@ -2378,12 +2408,12 @@ GraphBuilderOrt::AddLstmOperation(const LstmType& lstm) {
   attributes.push_back(model_editor_.CreateAttribute(
       /*name=*/"hidden_size", base::checked_cast<int64_t>(hidden_size)));
 
-  // TODO(https://github.com/shiyi9801/chromium/issues/195): Support ifgo
-  // layout.
-  if (lstm.layout != mojom::LstmWeightLayout::kIofg) {
-    return NewNotSupportedError(
-        "[WebNN] The lstm weight layout (ifgo) is not supported.");
-  }
+  // // TODO(https://github.com/shiyi9801/chromium/issues/195): Support ifgo
+  // // layout.
+  // if (lstm.layout != mojom::LstmWeightLayout::kIofg) {
+  //   return NewNotSupportedError(
+  //       "[WebNN] The lstm weight layout (ifgo) is not supported.");
+  // }
 
   std::string output, output_hidden, output_cell;
   if constexpr (std::is_same_v<LstmType, mojom::Lstm>) {

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -2408,13 +2408,6 @@ GraphBuilderOrt::AddLstmOperation(const LstmType& lstm) {
   attributes.push_back(model_editor_.CreateAttribute(
       /*name=*/"hidden_size", base::checked_cast<int64_t>(hidden_size)));
 
-  // // TODO(https://github.com/shiyi9801/chromium/issues/195): Support ifgo
-  // // layout.
-  // if (lstm.layout != mojom::LstmWeightLayout::kIofg) {
-  //   return NewNotSupportedError(
-  //       "[WebNN] The lstm weight layout (ifgo) is not supported.");
-  // }
-
   std::string output, output_hidden, output_cell;
   if constexpr (std::is_same_v<LstmType, mojom::Lstm>) {
     CHECK_GE(lstm.output_operand_ids.size(), 2u);

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -156,11 +156,17 @@ class GraphBuilderOrt {
                       OperandDataType input_data_type,
                       const std::vector<uint32_t>& bias_dims);
 
-  // A helper function used to reorder the weight and bias data for the RNN
+  // A helper function used to transpose the weight or bias layout for the RNN
   // operators (GRU, LSTM, etc.).
+  //
+  // Example:
+  //   To transpose gru weight or bias from "rzn" layout to "rzn" layout, pass
+  //   permutation as {1, 0, 2}.
+  //   To transpose lstm weight or bais from "ifgo" layout to "iofg" layout,
+  //   pass permutation as {0, 3, 1, 2}
   [[nodiscard]] base::expected<std::string, mojom::ErrorPtr>
-  ConvertRnnGateLayout(std::string_view weight_or_bias,
-                                   uint32_t num_gates);
+  TransposeRnnWeightOrBiasLayout(std::string_view weight_or_bias,
+                                 base::span<const uint32_t> permutation);
 
   std::string PrependTranspose(std::string_view input,
                                base::span<const uint32_t> permutation);

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -160,13 +160,13 @@ class GraphBuilderOrt {
   // operators (GRU, LSTM, etc.).
   //
   // Example:
-  //   To transpose gru weight or bias from "rzn" layout to "rzn" layout, pass
+  //   To transpose gru weight or bias from "rzn" layout to "zrn" layout, pass
   //   permutation as {1, 0, 2}.
   //   To transpose lstm weight or bais from "ifgo" layout to "iofg" layout,
   //   pass permutation as {0, 3, 1, 2}
-  [[nodiscard]] base::expected<std::string, mojom::ErrorPtr>
-  TransposeRnnWeightOrBiasLayout(std::string_view weight_or_bias,
-                                 base::span<const uint32_t> permutation);
+  std::string TransposeRnnWeightOrBiasLayout(
+      std::string_view weight_or_bias,
+      base::span<const uint32_t> permutation);
 
   std::string PrependTranspose(std::string_view input,
                                base::span<const uint32_t> permutation);

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -156,8 +156,11 @@ class GraphBuilderOrt {
                       OperandDataType input_data_type,
                       const std::vector<uint32_t>& bias_dims);
 
-  // A helper function used to convert the weight or bias from Rzn to Zrn.
-  std::string ConvertRznToZrn(std::string_view weight_or_bias);
+  // A helper function used to reorder the weight and bias data for the RNN
+  // operators (GRU, LSTM, etc.).
+  [[nodiscard]] base::expected<std::string, mojom::ErrorPtr>
+  ConvertRnnGateLayout(std::string_view weight_or_bias,
+                                   uint32_t num_gates);
 
   std::string PrependTranspose(std::string_view input,
                                base::span<const uint32_t> permutation);


### PR DESCRIPTION
This PR extends the previous ConvertRznToZrn() function to support converting the layout of lstm and lstmCell.
Fix #195 