### PR TITLE
Use `AddInitializerAsRawData` in ORT DML EP

### DIFF
--- a/services/webnn/ort/context_impl_ort.cc
+++ b/services/webnn/ort/context_impl_ort.cc
@@ -191,8 +191,15 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
     // display GPU installed on the system.
     CALL_ORT_FUNC(ort_dml_api->SessionOptionsAppendExecutionProvider_DML(
         session_options.get(), /*device_id=*/0));
+    // The DML ep does not support the use of memory pattern optimizations
+    // or parallel execution in onnxruntime.
+    CALL_ORT_FUNC(ort_api->DisableMemPattern(session_options.get()));
+    CALL_ORT_FUNC(ort_api->SetSessionExecutionMode(
+        session_options.get(), ExecutionMode::ORT_SEQUENTIAL));
     CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
         session_options.get(), "ep.dml.disable_graph_fusion", "1"));
+    CALL_ORT_FUNC(ort_api->AddSessionConfigEntry(
+        session_options.get(), "ep.dml.enable_graph_capture", "0"));
 #endif  // BUILDFLAG(IS_WIN)
   } else {
     // Use CPU EP by default.

--- a/services/webnn/ort/context_impl_ort.cc
+++ b/services/webnn/ort/context_impl_ort.cc
@@ -192,7 +192,7 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
     CALL_ORT_FUNC(ort_dml_api->SessionOptionsAppendExecutionProvider_DML(
         session_options.get(), /*device_id=*/0));
     // The DML ep does not support the use of memory pattern optimizations
-    // or parallel execution in onnxruntime
+    // or parallel execution in onnxruntime.
     // https://onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html#configuration-options
     CALL_ORT_FUNC(ort_api->DisableMemPattern(session_options.get()));
     CALL_ORT_FUNC(ort_api->SetSessionExecutionMode(

--- a/services/webnn/ort/context_impl_ort.cc
+++ b/services/webnn/ort/context_impl_ort.cc
@@ -192,7 +192,8 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
     CALL_ORT_FUNC(ort_dml_api->SessionOptionsAppendExecutionProvider_DML(
         session_options.get(), /*device_id=*/0));
     // The DML ep does not support the use of memory pattern optimizations
-    // or parallel execution in onnxruntime.
+    // or parallel execution in onnxruntime
+    // https://onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html#configuration-options
     CALL_ORT_FUNC(ort_api->DisableMemPattern(session_options.get()));
     CALL_ORT_FUNC(ort_api->SetSessionExecutionMode(
         session_options.get(), ExecutionMode::ORT_SEQUENTIAL));
@@ -265,7 +266,8 @@ ContextProperties ContextImplOrt::GetContextProperties() {
        /*batch_normalization_mean=*/
        {DataTypeConstraint::kFloat16To32, SupportedRanks::Exactly(1)},
        /*cast_input=*/{DataTypeConstraint::kAllDataTypesAtLeast8bits, kMaxRank},
-       /*clamp_input=*/{DataTypeConstraint::kAllDataTypesAtLeast8bits, kMaxRank},
+       /*clamp_input=*/
+       {DataTypeConstraint::kAllDataTypesAtLeast8bits, kMaxRank},
        /*concat_inputs=*/
        {DataTypeConstraint::kAllDataTypesAtLeast8bits, kMaxRank},
        /*conv2d_input=*/{DataTypeConstraint::kFloat16To32, {3, 8}},

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -419,7 +419,8 @@ base::expected<std::string, mojom::ErrorPtr> GraphBuilderOrt::CreateInitializer(
   ScopedOrtStatus status;
   // TODO(https://github.com/shiyi9801/chromium/issues/70): Remove this
   // workaround for OpenVINO EP once the invalid external data issue is fixed.
-  if (!base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino)) {
+  if (!(base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino) ||
+        base::FeatureList::IsEnabled(mojom::features::kWebNNOrtDml))) {
     status = model_editor_.AddInitializer(name, int64_shape, byte_span,
                                           TensorTypeMap<DataType>::value);
 
@@ -720,7 +721,8 @@ GraphBuilderOrt::AddInitializer(uint64_t constant_id) {
   ScopedOrtStatus status;
   // TODO(https://github.com/shiyi9801/chromium/issues/70): Remove this
   // workaround for OpenVINO EP once the invalid external data issue is fixed.
-  if (!base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino)) {
+  if (!(base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino) ||
+        base::FeatureList::IsEnabled(mojom::features::kWebNNOrtDml))) {
     status = model_editor_.AddInitializer(name, int64_shape, operand.ByteSpan(),
                                           onnx_data_type);
   } else {

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -419,7 +419,7 @@ base::expected<std::string, mojom::ErrorPtr> GraphBuilderOrt::CreateInitializer(
   ScopedOrtStatus status;
   // TODO(https://github.com/shiyi9801/chromium/issues/70,
   // https://github.com/shiyi9801/chromium/issues/209): Remove this workaround
-  // for OpenVINO&DML EP once the invalid external data issue is fixed.
+  // for OpenVINO and DML EP once the invalid external data issue is fixed.
   if (!(base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino) ||
         base::FeatureList::IsEnabled(mojom::features::kWebNNOrtDml))) {
     status = model_editor_.AddInitializer(name, int64_shape, byte_span,
@@ -722,7 +722,7 @@ GraphBuilderOrt::AddInitializer(uint64_t constant_id) {
   ScopedOrtStatus status;
   // TODO(https://github.com/shiyi9801/chromium/issues/70,
   // https://github.com/shiyi9801/chromium/issues/209): Remove this workaround
-  // for OpenVINO&DML EP once the invalid external data issue is fixed.
+  // for OpenVINO and DML EP once the invalid external data issue is fixed.
   if (!(base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino) ||
         base::FeatureList::IsEnabled(mojom::features::kWebNNOrtDml))) {
     status = model_editor_.AddInitializer(name, int64_shape, operand.ByteSpan(),

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -417,8 +417,9 @@ base::expected<std::string, mojom::ErrorPtr> GraphBuilderOrt::CreateInitializer(
   }
 
   ScopedOrtStatus status;
-  // TODO(https://github.com/shiyi9801/chromium/issues/70): Remove this
-  // workaround for OpenVINO EP once the invalid external data issue is fixed.
+  // TODO(https://github.com/shiyi9801/chromium/issues/70,
+  // https://github.com/shiyi9801/chromium/issues/209): Remove this workaround
+  // for OpenVINO&DML EP once the invalid external data issue is fixed.
   if (!(base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino) ||
         base::FeatureList::IsEnabled(mojom::features::kWebNNOrtDml))) {
     status = model_editor_.AddInitializer(name, int64_shape, byte_span,
@@ -719,8 +720,9 @@ GraphBuilderOrt::AddInitializer(uint64_t constant_id) {
   ONNXTensorElementDataType onnx_data_type =
       OperandTypeToONNXTensorElementDataType(operand.descriptor().data_type());
   ScopedOrtStatus status;
-  // TODO(https://github.com/shiyi9801/chromium/issues/70): Remove this
-  // workaround for OpenVINO EP once the invalid external data issue is fixed.
+  // TODO(https://github.com/shiyi9801/chromium/issues/70,
+  // https://github.com/shiyi9801/chromium/issues/209): Remove this workaround
+  // for OpenVINO&DML EP once the invalid external data issue is fixed.
   if (!(base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino) ||
         base::FeatureList::IsEnabled(mojom::features::kWebNNOrtDml))) {
     status = model_editor_.AddInitializer(name, int64_shape, operand.ByteSpan(),


### PR DESCRIPTION
Workaround for https://github.com/shiyi9801/chromium/issues/209.

Similar to https://github.com/shiyi9801/chromium/issues/70, if add initializer as external data, ORT DML EP will crash in execution.