### PR TITLE
Eliminate redundant cast ops around the logical operators

### DIFF
--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -426,6 +426,76 @@ GraphBuilderOrt::CreateScalarInitializer(const DataType& value) {
       /*shape=*/{}, base::span_from_ref(value));
 }
 
+void GraphBuilderOrt::OptimizeGraph() {
+  std::unordered_set<uint64_t> bool_output_operands;
+  std::unordered_set<uint64_t> bool_input_required_operands;
+  for (const mojom::OperationPtr& operation : graph_info_->operations) {
+    // Find all operands that are bool output.
+    switch (operation->which()) {
+      case mojom::Operation::Tag::kElementWiseBinary: {
+        const auto& binary = *operation->get_element_wise_binary();
+        if (binary.kind == mojom::ElementWiseBinary::Kind::kLesser ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kLesserOrEqual ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kGreater ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kGreaterOrEqual ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kEqual ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kNotEqual ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kLogicalAnd ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kLogicalOr ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kLogicalXor) {
+          bool_output_operands.insert(binary.output_operand_id);
+        }
+        break;
+      }
+      case mojom::Operation::Tag::kElementWiseUnary: {
+        const auto& unary = *operation->get_element_wise_unary();
+        if (unary.kind == mojom::ElementWiseUnary::Kind::kLogicalNot) {
+          bool_output_operands.insert(unary.output_operand_id);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    // Find all operands that are bool input required.
+    switch (operation->which()) {
+      case mojom::Operation::Tag::kElementWiseBinary: {
+        const auto& binary = *operation->get_element_wise_binary();
+        if (binary.kind == mojom::ElementWiseBinary::Kind::kLogicalAnd ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kLogicalOr ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kLogicalXor) {
+          bool_input_required_operands.insert(binary.lhs_operand_id);
+          bool_input_required_operands.insert(binary.rhs_operand_id);
+        }
+        break;
+      }
+      case mojom::Operation::Tag::kElementWiseUnary: {
+        const auto& unary = *operation->get_element_wise_unary();
+        if (unary.kind == mojom::ElementWiseUnary::Kind::kLogicalNot) {
+          bool_input_required_operands.insert(unary.input_operand_id);
+        }
+        break;
+      }
+      case mojom::Operation::Tag::kWhere: {
+        const auto& where = *operation->get_where();
+        bool_input_required_operands.insert(where.condition_operand_id);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  // Find all operands that can skip Cast operations. If an operand is a bool
+  // output and also a bool input required, it can skipCast operations.
+  for (auto id : bool_output_operands) {
+    if (bool_input_required_operands.count(id)) {
+      need_skip_cast_operands_.insert(id);
+    }
+  }
+}
+
 void GraphBuilderOrt::AddCastNode(std::string_view node,
                                   std::string_view input,
                                   std::string_view output,
@@ -848,15 +918,22 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
     lhs = GetOperandNameById(element_wise_binary->lhs_operand_id);
     rhs = GetOperandNameById(element_wise_binary->rhs_operand_id);
 
-    // Some ONNX logical operators only support bool input.
+    // For some ONNX logical operators that require bool input, add a cast if
+    // the operand is not in the skipped list.
     if (element_wise_binary->kind ==
             mojom::ElementWiseBinary::Kind::kLogicalAnd ||
         element_wise_binary->kind ==
             mojom::ElementWiseBinary::Kind::kLogicalOr ||
         element_wise_binary->kind ==
             mojom::ElementWiseBinary::Kind::kLogicalXor) {
-      lhs = PrependCast(lhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
-      rhs = PrependCast(rhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
+      if (!need_skip_cast_operands_.count(
+              element_wise_binary->lhs_operand_id)) {
+        lhs = PrependCast(lhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
+      }
+      if (!need_skip_cast_operands_.count(
+              element_wise_binary->rhs_operand_id)) {
+        rhs = PrependCast(rhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
+      }
     }
 
     inputs = {lhs.c_str(), rhs.c_str()};
@@ -865,30 +942,34 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
         absl::get<const mojom::ElementWiseUnary*>(operation);
     lhs = GetOperandNameById(element_wise_unary->input_operand_id);
 
-    // Some ONNX logical operators only support bool input.
+    // For some ONNX logical operators that require bool input, add a cast if
+    // the operand is not in the skipped list.
     if (element_wise_unary->kind ==
-        mojom::ElementWiseUnary::Kind::kLogicalNot) {
+            mojom::ElementWiseUnary::Kind::kLogicalNot &&
+        !need_skip_cast_operands_.count(element_wise_unary->input_operand_id)) {
       lhs = PrependCast(lhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
     }
 
     inputs = {lhs.c_str()};
   }
 
-  const std::string bool_output = GenerateNextOperandName();
-  std::array<const char*, 1> outputs = {bool_output.c_str()};
-
-  model_editor_.AddNode(op_type, node, inputs, outputs);
-
   // ONNX logical operators only support bool output. To support output with the
-  // WebNN data type, it is necessary to insert a cast operator after a logical
-  // operator.
+  // WebNN data type, append a cast if the operand is not in the skipped list.
   uint64_t output_operand_id = absl::visit(
       [](const auto* op) { return op->output_operand_id; }, operation);
-  OperandDataType output_data_type =
-      GetOperand(output_operand_id).descriptor.data_type();
   std::string output = GetOperandNameById(output_operand_id);
-  AppendCast(bool_output, output,
-             OperandTypeToONNXTensorElementDataType(output_data_type));
+  if (need_skip_cast_operands_.count(output_operand_id)) {
+    std::array<const char*, 1> outputs = {output.c_str()};
+    model_editor_.AddNode(op_type, node, inputs, outputs);
+  } else {
+    const std::string bool_output = GenerateNextOperandName();
+    std::array<const char*, 1> bool_outputs = {bool_output.c_str()};
+    model_editor_.AddNode(op_type, node, inputs, bool_outputs);
+    ONNXTensorElementDataType output_type =
+        OperandTypeToONNXTensorElementDataType(
+            GetOperand(output_operand_id).descriptor.data_type());
+    AppendCast(bool_output, output, output_type);
+  }
 }
 
 // ONNX doesn't support `notEqual`, emulate it by `logicalNot(equal(a, b))`.
@@ -906,22 +987,25 @@ void GraphBuilderOrt::AddElementWiseLogicalNotEqualOperation(
   model_editor_.AddNode(kOpTypeEqual, equal_node, equal_inputs, equal_outputs);
 
   // Step 2: calculate `logicalNot(equal_output)`
-  const std::string not_output = GenerateNextOperandName();
-  std::array<const char*, 1> not_outputs = {not_output.c_str()};
+  // ONNX logical operators only support bool output. To support output with the
+  // WebNN data type, append a cast if the operand is not in the skipped list.
+  uint64_t output_operand_id = not_equal.output_operand_id;
+  std::string output = GetOperandNameById(output_operand_id);
   const std::string not_node =
       GenerateNextOperationName("inserted_not_to_emulate_" + not_equal.label);
-  model_editor_.AddNode(kOpTypeLogicalNot, not_node, equal_outputs,
-                        not_outputs);
-
-  // ONNX logical operators only support bool output. To support output with the
-  // WebNN data type, it is necessary to insert a cast operator after a logical
-  // operator.
-  uint64_t output_operand_id = not_equal.output_operand_id;
-  OperandDataType output_data_type =
-      GetOperand(output_operand_id).descriptor.data_type();
-  std::string output = GetOperandNameById(output_operand_id);
-  AppendCast(not_output, output,
-             OperandTypeToONNXTensorElementDataType(output_data_type));
+  if (need_skip_cast_operands_.count(output_operand_id)) {
+    std::array<const char*, 1> outputs = {output.c_str()};
+    model_editor_.AddNode(kOpTypeLogicalNot, not_node, equal_outputs, outputs);
+  } else {
+    const std::string bool_output = GenerateNextOperandName();
+    std::array<const char*, 1> bool_outputs = {bool_output.c_str()};
+    model_editor_.AddNode(kOpTypeLogicalNot, not_node, equal_outputs,
+                          bool_outputs);
+    ONNXTensorElementDataType output_type =
+        OperandTypeToONNXTensorElementDataType(
+            GetOperand(output_operand_id).descriptor.data_type());
+    AppendCast(bool_output, output, output_type);
+  }
 }
 
 [[nodiscard]] base::expected<void, mojom::ErrorPtr>
@@ -3048,7 +3132,9 @@ void GraphBuilderOrt::AddWhereOperation(const mojom::Where& where) {
   // ONNX only supports bool data type for the condition input of Where, insert
   // a Cast node to convert the condition input to bool.
   std::string condition = GetOperandNameById(where.condition_operand_id);
-  condition = PrependCast(condition, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
+  if (!need_skip_cast_operands_.count(where.condition_operand_id)) {
+    condition = PrependCast(condition, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
+  }
 
   const std::string true_value =
       GetOperandNameById(where.true_value_operand_id);
@@ -3074,6 +3160,9 @@ GraphBuilderOrt::BuildModel() {
   for (const auto& [constant_id, _] : constant_operands_) {
     RETURN_IF_ERROR(AddInitializer(constant_id));
   }
+
+  // Optimize graph.
+  OptimizeGraph();
 
   // Add operations.
   for (const mojom::OperationPtr& operation : graph_info_->operations) {

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -487,8 +487,8 @@ void GraphBuilderOrt::OptimizeGraph() {
     }
   }
 
-  // Find all operands that can skip Cast operations. If an operand is a bool
-  // output and also a bool input required, it can skipCast operations.
+  // Find all operands that can skip cast operators. If an operand is a bool
+  // output and also a bool input required, it can skip cast operator.
   for (auto id : bool_output_operands) {
     if (bool_input_required_operands.count(id)) {
       need_skip_cast_operands_.insert(id);

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -426,9 +426,9 @@ GraphBuilderOrt::CreateScalarInitializer(const DataType& value) {
       /*shape=*/{}, base::span_from_ref(value));
 }
 
-void GraphBuilderOrt::OptimizeGraph() {
+void GraphBuilderOrt::FindBoolOperands() {
   std::unordered_set<uint64_t> bool_output_operands;
-  std::unordered_set<uint64_t> bool_input_required_operands;
+  std::unordered_set<uint64_t> bool_input_operands;
   for (const mojom::OperationPtr& operation : graph_info_->operations) {
     // Find all operands that are bool output.
     switch (operation->which()) {
@@ -458,28 +458,28 @@ void GraphBuilderOrt::OptimizeGraph() {
         break;
     }
 
-    // Find all operands that are bool input required.
+    // Find all operands that are used as bool input.
     switch (operation->which()) {
       case mojom::Operation::Tag::kElementWiseBinary: {
         const auto& binary = *operation->get_element_wise_binary();
         if (binary.kind == mojom::ElementWiseBinary::Kind::kLogicalAnd ||
             binary.kind == mojom::ElementWiseBinary::Kind::kLogicalOr ||
             binary.kind == mojom::ElementWiseBinary::Kind::kLogicalXor) {
-          bool_input_required_operands.insert(binary.lhs_operand_id);
-          bool_input_required_operands.insert(binary.rhs_operand_id);
+          bool_input_operands.insert(binary.lhs_operand_id);
+          bool_input_operands.insert(binary.rhs_operand_id);
         }
         break;
       }
       case mojom::Operation::Tag::kElementWiseUnary: {
         const auto& unary = *operation->get_element_wise_unary();
         if (unary.kind == mojom::ElementWiseUnary::Kind::kLogicalNot) {
-          bool_input_required_operands.insert(unary.input_operand_id);
+          bool_input_operands.insert(unary.input_operand_id);
         }
         break;
       }
       case mojom::Operation::Tag::kWhere: {
         const auto& where = *operation->get_where();
-        bool_input_required_operands.insert(where.condition_operand_id);
+        bool_input_operands.insert(where.condition_operand_id);
         break;
       }
       default:
@@ -488,10 +488,11 @@ void GraphBuilderOrt::OptimizeGraph() {
   }
 
   // Find all operands that can skip cast operators. If an operand is a bool
-  // output and also a bool input required, it can skip cast operator.
+  // output and also used as bool input, it can skip inserting cast operator
+  // to/from uint8.
   for (auto id : bool_output_operands) {
-    if (bool_input_required_operands.count(id)) {
-      need_skip_cast_operands_.insert(id);
+    if (bool_input_operands.count(id)) {
+      bool_operands_.insert(id);
     }
   }
 }
@@ -926,12 +927,10 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
             mojom::ElementWiseBinary::Kind::kLogicalOr ||
         element_wise_binary->kind ==
             mojom::ElementWiseBinary::Kind::kLogicalXor) {
-      if (!need_skip_cast_operands_.count(
-              element_wise_binary->lhs_operand_id)) {
+      if (!bool_operands_.count(element_wise_binary->lhs_operand_id)) {
         lhs = PrependCast(lhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
       }
-      if (!need_skip_cast_operands_.count(
-              element_wise_binary->rhs_operand_id)) {
+      if (!bool_operands_.count(element_wise_binary->rhs_operand_id)) {
         rhs = PrependCast(rhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
       }
     }
@@ -946,7 +945,7 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
     // the operand is not in the skipped list.
     if (element_wise_unary->kind ==
             mojom::ElementWiseUnary::Kind::kLogicalNot &&
-        !need_skip_cast_operands_.count(element_wise_unary->input_operand_id)) {
+        !bool_operands_.count(element_wise_unary->input_operand_id)) {
       lhs = PrependCast(lhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
     }
 
@@ -958,7 +957,7 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
   uint64_t output_operand_id = absl::visit(
       [](const auto* op) { return op->output_operand_id; }, operation);
   std::string output = GetOperandNameById(output_operand_id);
-  if (need_skip_cast_operands_.count(output_operand_id)) {
+  if (bool_operands_.count(output_operand_id)) {
     std::array<const char*, 1> outputs = {output.c_str()};
     model_editor_.AddNode(op_type, node, inputs, outputs);
   } else {
@@ -993,7 +992,7 @@ void GraphBuilderOrt::AddElementWiseLogicalNotEqualOperation(
   std::string output = GetOperandNameById(output_operand_id);
   const std::string not_node =
       GenerateNextOperationName("inserted_not_to_emulate_" + not_equal.label);
-  if (need_skip_cast_operands_.count(output_operand_id)) {
+  if (bool_operands_.count(output_operand_id)) {
     std::array<const char*, 1> outputs = {output.c_str()};
     model_editor_.AddNode(kOpTypeLogicalNot, not_node, equal_outputs, outputs);
   } else {
@@ -3132,7 +3131,7 @@ void GraphBuilderOrt::AddWhereOperation(const mojom::Where& where) {
   // ONNX only supports bool data type for the condition input of Where, insert
   // a Cast node to convert the condition input to bool.
   std::string condition = GetOperandNameById(where.condition_operand_id);
-  if (!need_skip_cast_operands_.count(where.condition_operand_id)) {
+  if (!bool_operands_.count(where.condition_operand_id)) {
     condition = PrependCast(condition, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
   }
 
@@ -3161,8 +3160,8 @@ GraphBuilderOrt::BuildModel() {
     RETURN_IF_ERROR(AddInitializer(constant_id));
   }
 
-  // Optimize graph.
-  OptimizeGraph();
+  // Find all the bool operands.
+  FindBoolOperands();
 
   // Add operations.
   for (const mojom::OperationPtr& operation : graph_info_->operations) {

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -125,6 +125,11 @@ class GraphBuilderOrt {
   [[nodiscard]] base::expected<std::string, mojom::ErrorPtr>
   CreateScalarInitializer(const DataType& value);
 
+  // Iterate over the graph info before adding nodes to optimize the model.
+  // For example, to find redundant cast nodes:
+  // [Less] -> Bool -> [Cast] -> Uint8 -> [Cast] -> Bool -> [Where]
+  void OptimizeGraph();
+
   void AddCastNode(std::string_view node,
                    std::string_view input,
                    std::string_view output,
@@ -323,6 +328,9 @@ class GraphBuilderOrt {
 
   // Used for inserting new operation into graph.
   uint64_t next_operation_id_ = 0;
+
+  // Used for skipping the cast operands that are redundant.
+  std::unordered_set<uint64_t> need_skip_cast_operands_;
 
   // A reference to the WebNN compute graph that `this` instance is converting
   // to ONNX model. The creator of `this` must ensure the GraphInfo reference

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -125,10 +125,10 @@ class GraphBuilderOrt {
   [[nodiscard]] base::expected<std::string, mojom::ErrorPtr>
   CreateScalarInitializer(const DataType& value);
 
-  // Iterate over the graph info before adding nodes to optimize the model.
-  // For example, to find redundant cast nodes:
+  // Iterate over the graph info before adding nodes to find the bool operands.
+  // For example:
   // [Less] -> Bool -> [Cast] -> Uint8 -> [Cast] -> Bool -> [Where]
-  void OptimizeGraph();
+  void FindBoolOperands();
 
   void AddCastNode(std::string_view node,
                    std::string_view input,
@@ -329,8 +329,9 @@ class GraphBuilderOrt {
   // Used for inserting new operation into graph.
   uint64_t next_operation_id_ = 0;
 
-  // Used for skipping the cast operands that are redundant.
-  std::unordered_set<uint64_t> need_skip_cast_operands_;
+  // Operands that can be kept in bool data type without inserting cast
+  // operators to/from uint8 data type.
+  std::unordered_set<uint64_t> bool_operands_;
 
   // A reference to the WebNN compute graph that `this` instance is converting
   // to ONNX model. The creator of `this` must ensure the GraphInfo reference

--- a/third_party/blink/web_tests/external/wpt/webnn/conformance_tests/optimize_graph.https.any.js
+++ b/third_party/blink/web_tests/external/wpt/webnn/conformance_tests/optimize_graph.https.any.js
@@ -1,0 +1,139 @@
+// META: title=test WebNN API optimized graph with logical operations
+// META: global=window,worker
+// META: variant=?cpu
+// META: variant=?gpu
+// META: variant=?npu
+// META: script=../resources/utils.js
+// META: timeout=long
+
+'use strict';
+
+const optimizedgraphTests = [
+  {
+    'name': 'Lesser + Where: [Less] -> Bool -> [Where]',
+    'graph': {
+      'inputs': {
+        'LesserInputA': {
+          'data': [2],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        },
+        'LesserInputB': {
+          'data': [1],
+          'descriptor': {shape: [1], dataType: 'float32'},
+        },
+        'whereTrueValue': {
+          'data': [2.2],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        },
+        'whereFalseValue': {
+          'data': [1.1],
+          'descriptor': {shape: [1], dataType: 'float32'},
+        }
+      },
+      'operators': [
+        {
+          'name': 'lesser',
+          'arguments': [{'a': 'LesserInputA'}, {'b': 'LesserInputB'}],
+          'outputs': 'lesserOutput'
+        },
+        {
+          'name': 'where',
+          'arguments': [{'condition': 'lesserOutput'}, {'trueValue,': 'whereTrueValue'}, {'falseValue': 'whereFalseValue'}],
+          'outputs': 'output'
+        },
+      ],
+      'expectedOutputs': {
+        'output': {
+          'data': [1.1],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        }
+      }
+    }
+  },
+  {
+    'name': 'Lesser + Add: [Less] -> Bool -> [Cast] -> Uint8 -> [Add]',
+    'graph': {
+      'inputs': {
+        'LesserInputA': {
+          'data': [2],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        },
+        'LesserInputB': {
+          'data': [1],
+          'descriptor': {shape: [1], dataType: 'float32'},
+        },
+        'AddInputB': {
+          'data': [3],
+          'descriptor': {shape: [1], dataType: 'uint8'}
+        }
+      },
+      'operators': [
+        {
+          'name': 'lesser',
+          'arguments': [{'a': 'LesserInputA'}, {'b': 'LesserInputB'}],
+          'outputs': 'lesserOutput'
+        },
+        {
+          'name': 'add',
+          'arguments': [{'a,': 'lesserOutput'}, {'b': 'AddInputB'}],
+          'outputs': 'output'
+        },
+      ],
+      'expectedOutputs': {
+        'output': {
+          'data': [3],
+          'descriptor': {shape: [1], dataType: 'uint8'}
+        }
+      }
+    }
+  },
+  {
+    'name': 'Add + Where: [Add] -> uint8 -> [Cast] -> bool -> [Where]',
+    'graph': {
+      'inputs': {
+        'AddInputA': {
+          'data': [2],
+          'descriptor': {shape: [1], dataType: 'uint8'}
+        },
+        'AddInputB': {
+          'data': [1],
+          'descriptor': {shape: [1], dataType: 'uint8'},
+        },
+        'whereTrueValue': {
+          'data': [2.2],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        },
+        'whereFalseValue': {
+          'data': [1.1],
+          'descriptor': {shape: [1], dataType: 'float32'},
+        }
+      },
+      'operators': [
+        {
+          'name': 'add',
+          'arguments': [{'a': 'AddInputA'}, {'b': 'AddInputB'}],
+          'outputs': 'addOutput'
+        },
+        {
+          'name': 'where',
+          'arguments': [{'condition': 'addOutput'}, {'trueValue,': 'whereTrueValue'}, {'falseValue': 'whereFalseValue'}],
+          'outputs': 'output'
+        },
+      ],
+      'expectedOutputs': {
+        'output': {
+          'data': [2.2],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        }
+      }
+    }
+  },
+];
+
+if (navigator.ml) {
+  optimizedgraphTests.forEach((test) => {
+    webnn_conformance_test(buildAndExecuteGraph, getPrecisionTolerance, test);
+  });
+} else {
+  test(() => assert_implements(navigator.ml, 'missing navigator.ml'));
+}


### PR DESCRIPTION
Fixed #187 .
It loops through the `graph_info` before add nodes. Find and eliminate the cast nodes that can be optimized.
@huningxin PTAL, thanks.