### PR TITLE
Allow to configure ORT logging level

### DIFF
--- a/content/browser/gpu/gpu_process_host.cc
+++ b/content/browser/gpu/gpu_process_host.cc
@@ -333,6 +333,7 @@ static const char* const kSwitchNames[] = {
     switches::kWebNNOrtDumpModel,
     switches::kWebNNOrtOVGpuPrecision,
     switches::kWebNNOrtUseOVModelCache,
+    switches::kWebNNOrtLoggingLevel,
 #endif
 };
 

--- a/services/webnn/webnn_context_provider_impl.cc
+++ b/services/webnn/webnn_context_provider_impl.cc
@@ -253,13 +253,32 @@ void WebNNContextProviderImpl::CreateWebNNContext(
       return;
     }
 
+    OrtLoggingLevel ort_logging_level = ORT_LOGGING_LEVEL_WARNING;
+    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kWebNNOrtLoggingLevel)) {
+      std::string user_logging_level =
+          base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
+              switches::kWebNNOrtLoggingLevel);
+      if (user_logging_level == "VERBOSE") {
+        ort_logging_level = ORT_LOGGING_LEVEL_VERBOSE;
+      } else if (user_logging_level == "INFO") {
+        ort_logging_level = ORT_LOGGING_LEVEL_INFO;
+      } else if (user_logging_level == "WARNING") {
+        ort_logging_level = ORT_LOGGING_LEVEL_WARNING;
+      } else if (user_logging_level == "ERROR") {
+        ort_logging_level = ORT_LOGGING_LEVEL_ERROR;
+      } else if (user_logging_level == "FATAL") {
+        ort_logging_level = ORT_LOGGING_LEVEL_FATAL;
+      }
+    }
+
     // `OrtEnv` is reference counted. The first `CreateEnv()` will create the
     // `OrtEnv` instance. The following invocations return the reference of the
     // same instance.  It is released upon the last reference is removed via
     // `ReleaseEnv()`.
     ort::ScopedOrtEnv env;
     if (ORT_CALL_FAILED(ort::GetOrtApi()->CreateEnv(
-            ORT_LOGGING_LEVEL_WARNING, "WebNN",
+            ort_logging_level, "WebNN",
             ort::ScopedOrtEnv::Receiver(env).get()))) {
       std::move(callback).Run(ToError<mojom::CreateContextResult>(
           mojom::Error::Code::kNotSupportedError,

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -56,6 +56,15 @@ inline constexpr char kWebNNOrtOVGpuPrecision[] = "webnn-ort-ov-gpu-precision";
 // This switch doesn't work if --webnn-ort-dump-model is enabled.
 inline constexpr char kWebNNOrtUseOVModelCache[] =
     "webnn-ort-use-ov-model-cache";
+
+// Configure the logging severity level of ONNX Runtime.
+// Usage: --no-sandbox --enable-logging --webnn-ort-logging-level=VERBOSE
+// Other severity levels could be "INFO", "WARNING" (default), "ERROR" and
+// "FATAL".
+// Please note if "--use-redist-ort" switch is used, this logging level
+// setting will be ignored, because an OrtEnv will be created before with
+// WARNING logging level.
+inline constexpr char kWebNNOrtLoggingLevel[] = "webnn-ort-logging-level";
 #endif  // BUILDFLAG(WEBNN_USE_ORT)
 
 }  // namespace switches


### PR DESCRIPTION
Add a switch to configure the logging severity level of ONNX Runtime.
Example usage: 
```
--no-sandbox --enable-logging --webnn-ort-logging-level=VERBOSE
```
Other severity levels could be "INFO", "WARNING" (default), "ERROR" and "FATAL".