### PR TITLE
Handle bool output is used by both bool input and uint8 input

### DIFF
--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -449,7 +449,7 @@ GraphBuilderOrt::CreateScalarInitializer(const DataType& value) {
 void GraphBuilderOrt::FindBoolOperands() {
   std::unordered_set<uint64_t> bool_output_operands;
   std::unordered_set<uint64_t> bool_input_operands;
-  std::unordered_set<uint64_t> uint8_input_operands;
+  std::unordered_set<uint64_t> may_uint8_input_operands;
   for (const mojom::OperationPtr& operation : graph_info_->operations) {
     // Find all operands that are bool output in ONNX.
     switch (operation->which()) {
@@ -507,34 +507,35 @@ void GraphBuilderOrt::FindBoolOperands() {
         break;
     }
 
-    // Find all operands that can used as uint8 input.
+    // Find all operands that may be used as uint8 input.
     switch (operation->which()) {
       case mojom::Operation::Tag::kArgMinMax: {
         const auto& arg_min_max = *operation->get_arg_min_max();
-        uint8_input_operands.insert(arg_min_max.input_operand_id);
+        may_uint8_input_operands.insert(arg_min_max.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kClamp: {
         const auto& clamp = *operation->get_clamp();
-        uint8_input_operands.insert(clamp.input_operand_id);
+        may_uint8_input_operands.insert(clamp.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kConcat: {
         const auto& concat = *operation->get_concat();
         for (const auto& input_operand_id : concat.input_operand_ids) {
-          uint8_input_operands.insert(input_operand_id);
+          may_uint8_input_operands.insert(input_operand_id);
         }
         break;
       }
       case mojom::Operation::Tag::kCumulativeSum: {
         const auto& cumulative_sum = *operation->get_cumulative_sum();
-        uint8_input_operands.insert(cumulative_sum.input_operand_id);
+        may_uint8_input_operands.insert(cumulative_sum.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kDequantizeLinear: {
         const auto& dequantize_linear = *operation->get_dequantize_linear();
-        uint8_input_operands.insert(dequantize_linear.input_operand_id);
-        uint8_input_operands.insert(dequantize_linear.zero_point_operand_id);
+        may_uint8_input_operands.insert(dequantize_linear.input_operand_id);
+        may_uint8_input_operands.insert(
+            dequantize_linear.zero_point_operand_id);
         break;
       }
       case mojom::Operation::Tag::kElementWiseBinary: {
@@ -551,8 +552,8 @@ void GraphBuilderOrt::FindBoolOperands() {
             binary.kind == mojom::ElementWiseBinary::Kind::kLesser ||
             binary.kind == mojom::ElementWiseBinary::Kind::kLesserOrEqual ||
             binary.kind == mojom::ElementWiseBinary::Kind::kNotEqual) {
-          uint8_input_operands.insert(binary.lhs_operand_id);
-          uint8_input_operands.insert(binary.rhs_operand_id);
+          may_uint8_input_operands.insert(binary.lhs_operand_id);
+          may_uint8_input_operands.insert(binary.rhs_operand_id);
         }
         break;
       }
@@ -561,89 +562,90 @@ void GraphBuilderOrt::FindBoolOperands() {
         if (unary.kind == mojom::ElementWiseUnary::Kind::kAbs ||
             unary.kind == mojom::ElementWiseUnary::Kind::kErf ||
             unary.kind == mojom::ElementWiseUnary::Kind::kIdentity) {
-          uint8_input_operands.insert(unary.input_operand_id);
+          may_uint8_input_operands.insert(unary.input_operand_id);
         }
         break;
       }
       case mojom::Operation::Tag::kExpand: {
         const auto& expand = *operation->get_expand();
-        uint8_input_operands.insert(expand.input_operand_id);
+        may_uint8_input_operands.insert(expand.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kGather: {
         const auto& gather = *operation->get_gather();
-        uint8_input_operands.insert(gather.input_operand_id);
+        may_uint8_input_operands.insert(gather.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kGatherElements: {
         const auto& gather_elements = *operation->get_gather_elements();
-        uint8_input_operands.insert(gather_elements.input_operand_id);
+        may_uint8_input_operands.insert(gather_elements.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kGatherNd: {
         const auto& gather_nd = *operation->get_gather_nd();
-        uint8_input_operands.insert(gather_nd.input_operand_id);
+        may_uint8_input_operands.insert(gather_nd.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kPad: {
-        // https://github.com/shiyi9801/chromium/issues/85
+        // TODO(https://github.com/shiyi9801/chromium/issues/85): handle uint8
+        // input once pad supports uint8 input.
         break;
       }
       case mojom::Operation::Tag::kResample2d: {
         const auto& resample = *operation->get_resample2d();
-        uint8_input_operands.insert(resample.input_operand_id);
+        may_uint8_input_operands.insert(resample.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kReshape: {
         const auto& reshape = *operation->get_reshape();
-        uint8_input_operands.insert(reshape.input_operand_id);
+        may_uint8_input_operands.insert(reshape.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kReverse: {
         const auto& reverse = *operation->get_reverse();
-        uint8_input_operands.insert(reverse.input_operand_id);
+        may_uint8_input_operands.insert(reverse.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kScatterElements: {
         const auto& scatter_elements = *operation->get_scatter_elements();
-        uint8_input_operands.insert(scatter_elements.input_operand_id);
+        may_uint8_input_operands.insert(scatter_elements.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kScatterNd: {
         const auto& scatter_nd = *operation->get_scatter_nd();
-        uint8_input_operands.insert(scatter_nd.input_operand_id);
-        uint8_input_operands.insert(scatter_nd.updates_operand_id);
+        may_uint8_input_operands.insert(scatter_nd.input_operand_id);
+        may_uint8_input_operands.insert(scatter_nd.updates_operand_id);
         break;
       }
       case mojom::Operation::Tag::kSlice: {
         const auto& slice = *operation->get_slice();
-        uint8_input_operands.insert(slice.input_operand_id);
+        may_uint8_input_operands.insert(slice.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kSplit: {
         const auto& split = *operation->get_split();
-        uint8_input_operands.insert(split.input_operand_id);
+        may_uint8_input_operands.insert(split.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kTile: {
         const auto& tile = *operation->get_tile();
-        uint8_input_operands.insert(tile.input_operand_id);
+        may_uint8_input_operands.insert(tile.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kTranspose: {
         const auto& transpose = *operation->get_transpose();
-        uint8_input_operands.insert(transpose.input_operand_id);
+        may_uint8_input_operands.insert(transpose.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kTriangular: {
         const auto& triangular = *operation->get_triangular();
-        uint8_input_operands.insert(triangular.input_operand_id);
+        may_uint8_input_operands.insert(triangular.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kWhere: {
         const auto& where = *operation->get_where();
-        uint8_input_operands.insert(where.true_value_operand_id);
-        uint8_input_operands.insert(where.false_value_operand_id);
+        may_uint8_input_operands.insert(where.true_value_operand_id);
+        may_uint8_input_operands.insert(where.false_value_operand_id);
         break;
       }
       default:
@@ -651,13 +653,14 @@ void GraphBuilderOrt::FindBoolOperands() {
     }
   }
 
-  // The output operands can also be viewed as the uint8 input operands.
+  // The graph output operands can also be viewed as the operands that may be
+  // used as uint8 input.
   for (const auto& output_operand_id : graph_info_->output_operands) {
-    uint8_input_operands.insert(output_operand_id);
+    may_uint8_input_operands.insert(output_operand_id);
   }
 
   for (auto id : bool_output_operands) {
-    // Find all operands that can skip cast operators. If an operand is a bool
+    // Find all operands that may skip cast operators. If an operand is a bool
     // output and also used as bool input, it can skip inserting cast operator
     // to/from uint8.
     if (bool_input_operands.count(id)) {
@@ -666,8 +669,8 @@ void GraphBuilderOrt::FindBoolOperands() {
     // Find all operands that should insert cast operators. If an operand is a
     // bool output and also used as uint8 input, it should insert cast operator
     // from bool to uint8.
-    if (uint8_input_operands.count(id)) {
-      bool_to_uint8_operands_.insert(id);
+    if (may_uint8_input_operands.count(id)) {
+      bool_operands_to_be_casted_to_uint8_.insert(id);
     }
   }
 }
@@ -1099,19 +1102,19 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
             mojom::ElementWiseBinary::Kind::kLogicalXor) {
       if (!bool_operands_.count(element_wise_binary->lhs_operand_id)) {
         lhs = PrependCast(lhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
-      }
-      // If the current operand is inserted a cast, find the bool operand
-      // through the original operand.
-      if (bool_to_uint8_operands_.count(element_wise_binary->lhs_operand_id)) {
-        lhs = operand_to_bool_operand_[lhs];
+      } else if (bool_operands_to_be_casted_to_uint8_.count(
+                     element_wise_binary->lhs_operand_id)) {
+        // If the current operand is casted from bool, find and use the bool
+        // operand.
+        lhs = uint8_to_bool_operands_map_[lhs];
       }
       if (!bool_operands_.count(element_wise_binary->rhs_operand_id)) {
         rhs = PrependCast(rhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
-      }
-      // If the current operand is inserted a cast, find the bool operand
-      // through the original operand.
-      if (bool_to_uint8_operands_.count(element_wise_binary->rhs_operand_id)) {
-        rhs = operand_to_bool_operand_[rhs];
+      } else if (bool_operands_to_be_casted_to_uint8_.count(
+                     element_wise_binary->rhs_operand_id)) {
+        // If the current operand is casted from bool, find and use the bool
+        // operand.
+        rhs = uint8_to_bool_operands_map_[rhs];
       }
     }
 
@@ -1127,11 +1130,11 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
         mojom::ElementWiseUnary::Kind::kLogicalNot) {
       if (!bool_operands_.count(element_wise_unary->input_operand_id)) {
         lhs = PrependCast(lhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
-      }
-      // If the current operand is inserted a cast, find the bool operand
-      // through the original operand.
-      if (bool_to_uint8_operands_.count(element_wise_unary->input_operand_id)) {
-        lhs = operand_to_bool_operand_[lhs];
+      } else if (bool_operands_to_be_casted_to_uint8_.count(
+                     element_wise_unary->input_operand_id)) {
+        // If the current operand is casted from bool, find and use the bool
+        // operand.
+        lhs = uint8_to_bool_operands_map_[lhs];
       }
     }
 
@@ -1144,7 +1147,7 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
   uint64_t output_operand_id = absl::visit(
       [](const auto* op) { return op->output_operand_id; }, operation);
   std::string output = GetOperandNameById(output_operand_id);
-  if (bool_to_uint8_operands_.count(output_operand_id)) {
+  if (bool_operands_to_be_casted_to_uint8_.count(output_operand_id)) {
     const std::string bool_output = GenerateNextOperandName();
     std::array<const char*, 1> bool_outputs = {bool_output.c_str()};
     model_editor_.AddNode(op_type, node, inputs, bool_outputs);
@@ -1154,7 +1157,7 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
     AppendCast(bool_output, output, output_type);
     // Store the mapping between the original operand and the bool operand after
     // inserting the cast.
-    operand_to_bool_operand_[output] = bool_output;
+    uint8_to_bool_operands_map_[output] = bool_output;
   } else {
     std::array<const char*, 1> outputs = {output.c_str()};
     model_editor_.AddNode(op_type, node, inputs, outputs);
@@ -1182,7 +1185,7 @@ void GraphBuilderOrt::AddElementWiseLogicalNotEqualOperation(
   std::string output = GetOperandNameById(output_operand_id);
   const std::string not_node =
       GenerateNextOperationName("inserted_not_to_emulate_" + not_equal.label);
-  if (bool_to_uint8_operands_.count(output_operand_id)) {
+  if (bool_operands_to_be_casted_to_uint8_.count(output_operand_id)) {
     const std::string bool_output = GenerateNextOperandName();
     std::array<const char*, 1> bool_outputs = {bool_output.c_str()};
     model_editor_.AddNode(kOpTypeLogicalNot, not_node, equal_outputs,
@@ -1193,7 +1196,7 @@ void GraphBuilderOrt::AddElementWiseLogicalNotEqualOperation(
     AppendCast(bool_output, output, output_type);
     // Store the mapping between the original operand and the bool operand after
     // inserting the cast.
-    operand_to_bool_operand_[output] = bool_output;
+    uint8_to_bool_operands_map_[output] = bool_output;
   } else {
     std::array<const char*, 1> outputs = {output.c_str()};
     model_editor_.AddNode(kOpTypeLogicalNot, not_node, equal_outputs, outputs);
@@ -3374,11 +3377,11 @@ void GraphBuilderOrt::AddWhereOperation(const mojom::Where& where) {
   std::string condition = GetOperandNameById(where.condition_operand_id);
   if (!bool_operands_.count(where.condition_operand_id)) {
     condition = PrependCast(condition, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
-  }
-  // If the current operand is inserted a cast, find the bool operand through
-  // the original operand.
-  if (bool_to_uint8_operands_.count(where.condition_operand_id)) {
-    condition = operand_to_bool_operand_[condition];
+  } else if (bool_operands_to_be_casted_to_uint8_.count(
+                 where.condition_operand_id)) {
+    // If the current operand is casted from bool, find and use the bool
+    // operand.
+    condition = uint8_to_bool_operands_map_[condition];
   }
   const std::string true_value =
       GetOperandNameById(where.true_value_operand_id);

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -451,7 +451,7 @@ void GraphBuilderOrt::FindBoolOperands() {
   std::unordered_set<uint64_t> bool_input_operands;
   std::unordered_set<uint64_t> uint8_input_operands;
   for (const mojom::OperationPtr& operation : graph_info_->operations) {
-    // Find all operands that are bool output.
+    // Find all operands that are bool output in ONNX.
     switch (operation->which()) {
       case mojom::Operation::Tag::kElementWiseBinary: {
         const auto& binary = *operation->get_element_wise_binary();
@@ -479,7 +479,7 @@ void GraphBuilderOrt::FindBoolOperands() {
         break;
     }
 
-    // Find all operands that are used as bool input.
+    // Find all operands that are used as bool input in ONNX.
     switch (operation->which()) {
       case mojom::Operation::Tag::kElementWiseBinary: {
         const auto& binary = *operation->get_element_wise_binary();
@@ -656,12 +656,18 @@ void GraphBuilderOrt::FindBoolOperands() {
     uint8_input_operands.insert(output_operand_id);
   }
 
-  // Find all operands that can skip cast operators. If a bool output operand is
-  // used as bool input and not used as uint8 input at the same time, it can
-  // skip inserting cast operator to/from uint8.
   for (auto id : bool_output_operands) {
-    if (bool_input_operands.count(id) && !uint8_input_operands.count(id)) {
+    // Find all operands that can skip cast operators. If an operand is a bool
+    // output and also used as bool input, it can skip inserting cast operator
+    // to/from uint8.
+    if (bool_input_operands.count(id)) {
       bool_operands_.insert(id);
+    }
+    // Find all operands that should insert cast operators. If an operand is a
+    // bool output and also used as uint8 input, it should insert cast operator
+    // from bool to uint8.
+    if (uint8_input_operands.count(id)) {
+      bool_to_uint8_operands_.insert(id);
     }
   }
 }
@@ -1094,8 +1100,18 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
       if (!bool_operands_.count(element_wise_binary->lhs_operand_id)) {
         lhs = PrependCast(lhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
       }
+      // If the current operand is inserted a cast, find the bool operand
+      // through the original operand.
+      if (bool_to_uint8_operands_.count(element_wise_binary->lhs_operand_id)) {
+        lhs = operand_to_bool_operand_[lhs];
+      }
       if (!bool_operands_.count(element_wise_binary->rhs_operand_id)) {
         rhs = PrependCast(rhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
+      }
+      // If the current operand is inserted a cast, find the bool operand
+      // through the original operand.
+      if (bool_to_uint8_operands_.count(element_wise_binary->rhs_operand_id)) {
+        rhs = operand_to_bool_operand_[rhs];
       }
     }
 
@@ -1108,23 +1124,27 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
     // For some ONNX logical operators that require bool input, add a cast if
     // the operand is not in the skipped list.
     if (element_wise_unary->kind ==
-            mojom::ElementWiseUnary::Kind::kLogicalNot &&
-        !bool_operands_.count(element_wise_unary->input_operand_id)) {
-      lhs = PrependCast(lhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
+        mojom::ElementWiseUnary::Kind::kLogicalNot) {
+      if (!bool_operands_.count(element_wise_unary->input_operand_id)) {
+        lhs = PrependCast(lhs, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
+      }
+      // If the current operand is inserted a cast, find the bool operand
+      // through the original operand.
+      if (bool_to_uint8_operands_.count(element_wise_unary->input_operand_id)) {
+        lhs = operand_to_bool_operand_[lhs];
+      }
     }
 
     inputs = {lhs.c_str()};
   }
 
   // ONNX logical operators only support bool output. To support output with the
-  // WebNN data type, append a cast if the operand is not in the skipped list.
+  // WebNN data type, append a cast if the operand is used by a node that
+  // requires a uint8 input.
   uint64_t output_operand_id = absl::visit(
       [](const auto* op) { return op->output_operand_id; }, operation);
   std::string output = GetOperandNameById(output_operand_id);
-  if (bool_operands_.count(output_operand_id)) {
-    std::array<const char*, 1> outputs = {output.c_str()};
-    model_editor_.AddNode(op_type, node, inputs, outputs);
-  } else {
+  if (bool_to_uint8_operands_.count(output_operand_id)) {
     const std::string bool_output = GenerateNextOperandName();
     std::array<const char*, 1> bool_outputs = {bool_output.c_str()};
     model_editor_.AddNode(op_type, node, inputs, bool_outputs);
@@ -1132,6 +1152,12 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
         OperandTypeToONNXTensorElementDataType(
             GetOperand(output_operand_id).descriptor.data_type());
     AppendCast(bool_output, output, output_type);
+    // Store the mapping between the original operand and the bool operand after
+    // inserting the cast.
+    operand_to_bool_operand_[output] = bool_output;
+  } else {
+    std::array<const char*, 1> outputs = {output.c_str()};
+    model_editor_.AddNode(op_type, node, inputs, outputs);
   }
 }
 
@@ -1156,10 +1182,7 @@ void GraphBuilderOrt::AddElementWiseLogicalNotEqualOperation(
   std::string output = GetOperandNameById(output_operand_id);
   const std::string not_node =
       GenerateNextOperationName("inserted_not_to_emulate_" + not_equal.label);
-  if (bool_operands_.count(output_operand_id)) {
-    std::array<const char*, 1> outputs = {output.c_str()};
-    model_editor_.AddNode(kOpTypeLogicalNot, not_node, equal_outputs, outputs);
-  } else {
+  if (bool_to_uint8_operands_.count(output_operand_id)) {
     const std::string bool_output = GenerateNextOperandName();
     std::array<const char*, 1> bool_outputs = {bool_output.c_str()};
     model_editor_.AddNode(kOpTypeLogicalNot, not_node, equal_outputs,
@@ -1168,6 +1191,12 @@ void GraphBuilderOrt::AddElementWiseLogicalNotEqualOperation(
         OperandTypeToONNXTensorElementDataType(
             GetOperand(output_operand_id).descriptor.data_type());
     AppendCast(bool_output, output, output_type);
+    // Store the mapping between the original operand and the bool operand after
+    // inserting the cast.
+    operand_to_bool_operand_[output] = bool_output;
+  } else {
+    std::array<const char*, 1> outputs = {output.c_str()};
+    model_editor_.AddNode(kOpTypeLogicalNot, not_node, equal_outputs, outputs);
   }
 }
 
@@ -3346,7 +3375,11 @@ void GraphBuilderOrt::AddWhereOperation(const mojom::Where& where) {
   if (!bool_operands_.count(where.condition_operand_id)) {
     condition = PrependCast(condition, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
   }
-
+  // If the current operand is inserted a cast, find the bool operand through
+  // the original operand.
+  if (bool_to_uint8_operands_.count(where.condition_operand_id)) {
+    condition = operand_to_bool_operand_[condition];
+  }
   const std::string true_value =
       GetOperandNameById(where.true_value_operand_id);
   const std::string false_value =

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -449,7 +449,7 @@ GraphBuilderOrt::CreateScalarInitializer(const DataType& value) {
 void GraphBuilderOrt::FindBoolOperands() {
   std::unordered_set<uint64_t> bool_output_operands;
   std::unordered_set<uint64_t> bool_input_operands;
-  std::unordered_set<uint64_t> may_uint8_input_operands;
+  std::unordered_set<uint64_t> maybe_uint8_input_operands;
   for (const mojom::OperationPtr& operation : graph_info_->operations) {
     // Find all operands that are bool output in ONNX.
     switch (operation->which()) {
@@ -511,30 +511,30 @@ void GraphBuilderOrt::FindBoolOperands() {
     switch (operation->which()) {
       case mojom::Operation::Tag::kArgMinMax: {
         const auto& arg_min_max = *operation->get_arg_min_max();
-        may_uint8_input_operands.insert(arg_min_max.input_operand_id);
+        maybe_uint8_input_operands.insert(arg_min_max.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kClamp: {
         const auto& clamp = *operation->get_clamp();
-        may_uint8_input_operands.insert(clamp.input_operand_id);
+        maybe_uint8_input_operands.insert(clamp.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kConcat: {
         const auto& concat = *operation->get_concat();
         for (const auto& input_operand_id : concat.input_operand_ids) {
-          may_uint8_input_operands.insert(input_operand_id);
+          maybe_uint8_input_operands.insert(input_operand_id);
         }
         break;
       }
       case mojom::Operation::Tag::kCumulativeSum: {
         const auto& cumulative_sum = *operation->get_cumulative_sum();
-        may_uint8_input_operands.insert(cumulative_sum.input_operand_id);
+        maybe_uint8_input_operands.insert(cumulative_sum.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kDequantizeLinear: {
         const auto& dequantize_linear = *operation->get_dequantize_linear();
-        may_uint8_input_operands.insert(dequantize_linear.input_operand_id);
-        may_uint8_input_operands.insert(
+        maybe_uint8_input_operands.insert(dequantize_linear.input_operand_id);
+        maybe_uint8_input_operands.insert(
             dequantize_linear.zero_point_operand_id);
         break;
       }
@@ -552,8 +552,8 @@ void GraphBuilderOrt::FindBoolOperands() {
             binary.kind == mojom::ElementWiseBinary::Kind::kLesser ||
             binary.kind == mojom::ElementWiseBinary::Kind::kLesserOrEqual ||
             binary.kind == mojom::ElementWiseBinary::Kind::kNotEqual) {
-          may_uint8_input_operands.insert(binary.lhs_operand_id);
-          may_uint8_input_operands.insert(binary.rhs_operand_id);
+          maybe_uint8_input_operands.insert(binary.lhs_operand_id);
+          maybe_uint8_input_operands.insert(binary.rhs_operand_id);
         }
         break;
       }
@@ -562,28 +562,28 @@ void GraphBuilderOrt::FindBoolOperands() {
         if (unary.kind == mojom::ElementWiseUnary::Kind::kAbs ||
             unary.kind == mojom::ElementWiseUnary::Kind::kErf ||
             unary.kind == mojom::ElementWiseUnary::Kind::kIdentity) {
-          may_uint8_input_operands.insert(unary.input_operand_id);
+          maybe_uint8_input_operands.insert(unary.input_operand_id);
         }
         break;
       }
       case mojom::Operation::Tag::kExpand: {
         const auto& expand = *operation->get_expand();
-        may_uint8_input_operands.insert(expand.input_operand_id);
+        maybe_uint8_input_operands.insert(expand.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kGather: {
         const auto& gather = *operation->get_gather();
-        may_uint8_input_operands.insert(gather.input_operand_id);
+        maybe_uint8_input_operands.insert(gather.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kGatherElements: {
         const auto& gather_elements = *operation->get_gather_elements();
-        may_uint8_input_operands.insert(gather_elements.input_operand_id);
+        maybe_uint8_input_operands.insert(gather_elements.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kGatherNd: {
         const auto& gather_nd = *operation->get_gather_nd();
-        may_uint8_input_operands.insert(gather_nd.input_operand_id);
+        maybe_uint8_input_operands.insert(gather_nd.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kPad: {
@@ -593,59 +593,59 @@ void GraphBuilderOrt::FindBoolOperands() {
       }
       case mojom::Operation::Tag::kResample2d: {
         const auto& resample = *operation->get_resample2d();
-        may_uint8_input_operands.insert(resample.input_operand_id);
+        maybe_uint8_input_operands.insert(resample.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kReshape: {
         const auto& reshape = *operation->get_reshape();
-        may_uint8_input_operands.insert(reshape.input_operand_id);
+        maybe_uint8_input_operands.insert(reshape.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kReverse: {
         const auto& reverse = *operation->get_reverse();
-        may_uint8_input_operands.insert(reverse.input_operand_id);
+        maybe_uint8_input_operands.insert(reverse.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kScatterElements: {
         const auto& scatter_elements = *operation->get_scatter_elements();
-        may_uint8_input_operands.insert(scatter_elements.input_operand_id);
+        maybe_uint8_input_operands.insert(scatter_elements.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kScatterNd: {
         const auto& scatter_nd = *operation->get_scatter_nd();
-        may_uint8_input_operands.insert(scatter_nd.input_operand_id);
-        may_uint8_input_operands.insert(scatter_nd.updates_operand_id);
+        maybe_uint8_input_operands.insert(scatter_nd.input_operand_id);
+        maybe_uint8_input_operands.insert(scatter_nd.updates_operand_id);
         break;
       }
       case mojom::Operation::Tag::kSlice: {
         const auto& slice = *operation->get_slice();
-        may_uint8_input_operands.insert(slice.input_operand_id);
+        maybe_uint8_input_operands.insert(slice.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kSplit: {
         const auto& split = *operation->get_split();
-        may_uint8_input_operands.insert(split.input_operand_id);
+        maybe_uint8_input_operands.insert(split.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kTile: {
         const auto& tile = *operation->get_tile();
-        may_uint8_input_operands.insert(tile.input_operand_id);
+        maybe_uint8_input_operands.insert(tile.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kTranspose: {
         const auto& transpose = *operation->get_transpose();
-        may_uint8_input_operands.insert(transpose.input_operand_id);
+        maybe_uint8_input_operands.insert(transpose.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kTriangular: {
         const auto& triangular = *operation->get_triangular();
-        may_uint8_input_operands.insert(triangular.input_operand_id);
+        maybe_uint8_input_operands.insert(triangular.input_operand_id);
         break;
       }
       case mojom::Operation::Tag::kWhere: {
         const auto& where = *operation->get_where();
-        may_uint8_input_operands.insert(where.true_value_operand_id);
-        may_uint8_input_operands.insert(where.false_value_operand_id);
+        maybe_uint8_input_operands.insert(where.true_value_operand_id);
+        maybe_uint8_input_operands.insert(where.false_value_operand_id);
         break;
       }
       default:
@@ -656,7 +656,7 @@ void GraphBuilderOrt::FindBoolOperands() {
   // The graph output operands can also be viewed as the operands that may be
   // used as uint8 input.
   for (const auto& output_operand_id : graph_info_->output_operands) {
-    may_uint8_input_operands.insert(output_operand_id);
+    maybe_uint8_input_operands.insert(output_operand_id);
   }
 
   for (auto id : bool_output_operands) {
@@ -669,7 +669,7 @@ void GraphBuilderOrt::FindBoolOperands() {
     // Find all operands that should insert cast operators. If an operand is a
     // bool output and also used as uint8 input, it should insert cast operator
     // from bool to uint8.
-    if (may_uint8_input_operands.count(id)) {
+    if (maybe_uint8_input_operands.count(id)) {
       bool_operands_to_be_casted_to_uint8_.insert(id);
     }
   }
@@ -1155,8 +1155,8 @@ void GraphBuilderOrt::AddElementWiseLogicalOperation(
         OperandTypeToONNXTensorElementDataType(
             GetOperand(output_operand_id).descriptor.data_type());
     AppendCast(bool_output, output, output_type);
-    // Store the mapping between the original operand and the bool operand after
-    // inserting the cast.
+    // Store the mapping between the casted operand and the original bool
+    // operand after inserting the cast.
     uint8_to_bool_operands_map_[output] = bool_output;
   } else {
     std::array<const char*, 1> outputs = {output.c_str()};
@@ -1194,8 +1194,8 @@ void GraphBuilderOrt::AddElementWiseLogicalNotEqualOperation(
         OperandTypeToONNXTensorElementDataType(
             GetOperand(output_operand_id).descriptor.data_type());
     AppendCast(bool_output, output, output_type);
-    // Store the mapping between the original operand and the bool operand after
-    // inserting the cast.
+    // Store the mapping between the casted operand and the original bool
+    // operand after inserting the cast.
     uint8_to_bool_operands_map_[output] = bool_output;
   } else {
     std::array<const char*, 1> outputs = {output.c_str()};

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -449,6 +449,7 @@ GraphBuilderOrt::CreateScalarInitializer(const DataType& value) {
 void GraphBuilderOrt::FindBoolOperands() {
   std::unordered_set<uint64_t> bool_output_operands;
   std::unordered_set<uint64_t> bool_input_operands;
+  std::unordered_set<uint64_t> uint8_input_operands;
   for (const mojom::OperationPtr& operation : graph_info_->operations) {
     // Find all operands that are bool output.
     switch (operation->which()) {
@@ -505,13 +506,161 @@ void GraphBuilderOrt::FindBoolOperands() {
       default:
         break;
     }
+
+    // Find all operands that can used as uint8 input.
+    switch (operation->which()) {
+      case mojom::Operation::Tag::kArgMinMax: {
+        const auto& arg_min_max = *operation->get_arg_min_max();
+        uint8_input_operands.insert(arg_min_max.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kClamp: {
+        const auto& clamp = *operation->get_clamp();
+        uint8_input_operands.insert(clamp.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kConcat: {
+        const auto& concat = *operation->get_concat();
+        for (const auto& input_operand_id : concat.input_operand_ids) {
+          uint8_input_operands.insert(input_operand_id);
+        }
+        break;
+      }
+      case mojom::Operation::Tag::kCumulativeSum: {
+        const auto& cumulative_sum = *operation->get_cumulative_sum();
+        uint8_input_operands.insert(cumulative_sum.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kDequantizeLinear: {
+        const auto& dequantize_linear = *operation->get_dequantize_linear();
+        uint8_input_operands.insert(dequantize_linear.input_operand_id);
+        uint8_input_operands.insert(dequantize_linear.zero_point_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kElementWiseBinary: {
+        const auto& binary = *operation->get_element_wise_binary();
+        if (binary.kind == mojom::ElementWiseBinary::Kind::kAdd ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kSub ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kMul ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kDiv ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kMax ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kMin ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kEqual ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kGreater ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kGreaterOrEqual ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kLesser ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kLesserOrEqual ||
+            binary.kind == mojom::ElementWiseBinary::Kind::kNotEqual) {
+          uint8_input_operands.insert(binary.lhs_operand_id);
+          uint8_input_operands.insert(binary.rhs_operand_id);
+        }
+        break;
+      }
+      case mojom::Operation::Tag::kElementWiseUnary: {
+        const auto& unary = *operation->get_element_wise_unary();
+        if (unary.kind == mojom::ElementWiseUnary::Kind::kAbs ||
+            unary.kind == mojom::ElementWiseUnary::Kind::kErf ||
+            unary.kind == mojom::ElementWiseUnary::Kind::kIdentity) {
+          uint8_input_operands.insert(unary.input_operand_id);
+        }
+        break;
+      }
+      case mojom::Operation::Tag::kExpand: {
+        const auto& expand = *operation->get_expand();
+        uint8_input_operands.insert(expand.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kGather: {
+        const auto& gather = *operation->get_gather();
+        uint8_input_operands.insert(gather.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kGatherElements: {
+        const auto& gather_elements = *operation->get_gather_elements();
+        uint8_input_operands.insert(gather_elements.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kGatherNd: {
+        const auto& gather_nd = *operation->get_gather_nd();
+        uint8_input_operands.insert(gather_nd.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kPad: {
+        // https://github.com/shiyi9801/chromium/issues/85
+        break;
+      }
+      case mojom::Operation::Tag::kResample2d: {
+        const auto& resample = *operation->get_resample2d();
+        uint8_input_operands.insert(resample.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kReshape: {
+        const auto& reshape = *operation->get_reshape();
+        uint8_input_operands.insert(reshape.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kReverse: {
+        const auto& reverse = *operation->get_reverse();
+        uint8_input_operands.insert(reverse.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kScatterElements: {
+        const auto& scatter_elements = *operation->get_scatter_elements();
+        uint8_input_operands.insert(scatter_elements.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kScatterNd: {
+        const auto& scatter_nd = *operation->get_scatter_nd();
+        uint8_input_operands.insert(scatter_nd.input_operand_id);
+        uint8_input_operands.insert(scatter_nd.updates_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kSlice: {
+        const auto& slice = *operation->get_slice();
+        uint8_input_operands.insert(slice.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kSplit: {
+        const auto& split = *operation->get_split();
+        uint8_input_operands.insert(split.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kTile: {
+        const auto& tile = *operation->get_tile();
+        uint8_input_operands.insert(tile.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kTranspose: {
+        const auto& transpose = *operation->get_transpose();
+        uint8_input_operands.insert(transpose.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kTriangular: {
+        const auto& triangular = *operation->get_triangular();
+        uint8_input_operands.insert(triangular.input_operand_id);
+        break;
+      }
+      case mojom::Operation::Tag::kWhere: {
+        const auto& where = *operation->get_where();
+        uint8_input_operands.insert(where.true_value_operand_id);
+        uint8_input_operands.insert(where.false_value_operand_id);
+        break;
+      }
+      default:
+        break;
+    }
   }
 
-  // Find all operands that can skip cast operators. If an operand is a bool
-  // output and also used as bool input, it can skip inserting cast operator
-  // to/from uint8.
+  // The output operands can also be viewed as the uint8 input operands.
+  for (const auto& output_operand_id : graph_info_->output_operands) {
+    uint8_input_operands.insert(output_operand_id);
+  }
+
+  // Find all operands that can skip cast operators. If a bool output operand is
+  // used as bool input and not used as uint8 input at the same time, it can
+  // skip inserting cast operator to/from uint8.
   for (auto id : bool_output_operands) {
-    if (bool_input_operands.count(id)) {
+    if (bool_input_operands.count(id) && !uint8_input_operands.count(id)) {
       bool_operands_.insert(id);
     }
   }

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -340,11 +340,12 @@ class GraphBuilderOrt {
   // operators to/from uint8 data type.
   std::unordered_set<uint64_t> bool_operands_;
 
-  // Operands that should be inserted cast operators from bool to uint8.
-  std::unordered_set<uint64_t> bool_to_uint8_operands_;
+  // Bool operands that should casted to uint8.
+  std::unordered_set<uint64_t> bool_operands_to_be_casted_to_uint8_;
 
-  // Operands that mapped to bool operands after inserting the cast operators.
-  std::unordered_map<std::string, std::string> operand_to_bool_operand_;
+  // Map the uint8 operands back to bool operands after inserting the cast
+  // operators.
+  std::unordered_map<std::string, std::string> uint8_to_bool_operands_map_;
 
   // A reference to the WebNN compute graph that `this` instance is converting
   // to ONNX model. The creator of `this` must ensure the GraphInfo reference

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -340,6 +340,12 @@ class GraphBuilderOrt {
   // operators to/from uint8 data type.
   std::unordered_set<uint64_t> bool_operands_;
 
+  // Operands that should be inserted cast operators from bool to uint8.
+  std::unordered_set<uint64_t> bool_to_uint8_operands_;
+
+  // Operands that mapped to bool operands after inserting the cast operators.
+  std::unordered_map<std::string, std::string> operand_to_bool_operand_;
+
   // A reference to the WebNN compute graph that `this` instance is converting
   // to ONNX model. The creator of `this` must ensure the GraphInfo reference
   // passed into `CreateAndBuild()` is valid for as long as `this` exists.

--- a/services/webnn/ort/graph_builder_ort.h
+++ b/services/webnn/ort/graph_builder_ort.h
@@ -340,10 +340,10 @@ class GraphBuilderOrt {
   // operators to/from uint8 data type.
   std::unordered_set<uint64_t> bool_operands_;
 
-  // Bool operands that should casted to uint8.
+  // Bool operands that should be casted to uint8.
   std::unordered_set<uint64_t> bool_operands_to_be_casted_to_uint8_;
 
-  // Map the uint8 operands back to bool operands after inserting the cast
+  // Map the uint8 operands back to the bool operands after inserting the cast
   // operators.
   std::unordered_map<std::string, std::string> uint8_to_bool_operands_map_;
 

--- a/third_party/blink/web_tests/external/wpt/webnn/conformance_tests/optimize_graph.https.any.js
+++ b/third_party/blink/web_tests/external/wpt/webnn/conformance_tests/optimize_graph.https.any.js
@@ -128,6 +128,105 @@ const optimizedgraphTests = [
       }
     }
   },
+  {
+    'name': 'Lesser + Where & output: [Less] -> Bool -> [Where] & [Less] -> [Cast] -> uint8(output)',
+    'graph': {
+      'inputs': {
+        'LesserInputA': {
+          'data': [2],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        },
+        'LesserInputB': {
+          'data': [1],
+          'descriptor': {shape: [1], dataType: 'float32'},
+        },
+        'whereTrueValue': {
+          'data': [2.2],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        },
+        'whereFalseValue': {
+          'data': [1.1],
+          'descriptor': {shape: [1], dataType: 'float32'},
+        }
+      },
+      'operators': [
+        {
+          'name': 'lesser',
+          'arguments': [{'a': 'LesserInputA'}, {'b': 'LesserInputB'}],
+          'outputs': 'lesserOutput'
+        },
+        {
+          'name': 'where',
+          'arguments': [{'condition': 'lesserOutput'}, {'trueValue,': 'whereTrueValue'}, {'falseValue': 'whereFalseValue'}],
+          'outputs': 'whereOutput'
+        },
+      ],
+      'expectedOutputs': {
+        'lesserOutput': {
+          'data': [0],
+          'descriptor': {shape: [1], dataType: 'uint8'}
+        },
+        'whereOutput': {
+          'data': [1.1],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        }
+      }
+    }
+  },
+  {
+    'name': 'Lesser + Where & Add: [Less] -> Bool -> [Where] & [Less] -> Bool -> [Cast] -> uint8 -> [Add]',
+    'graph': {
+      'inputs': {
+        'LesserInputA': {
+          'data': [2],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        },
+        'LesserInputB': {
+          'data': [1],
+          'descriptor': {shape: [1], dataType: 'float32'},
+        },
+        'whereTrueValue': {
+          'data': [2.2],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        },
+        'whereFalseValue': {
+          'data': [1.1],
+          'descriptor': {shape: [1], dataType: 'float32'},
+        },
+        'AddInputB': {
+          'data': [2],
+          'descriptor': {shape: [1], dataType: 'uint8'},
+        }
+      },
+      'operators': [
+        {
+          'name': 'lesser',
+          'arguments': [{'a': 'LesserInputA'}, {'b': 'LesserInputB'}],
+          'outputs': 'lesserOutput'
+        },
+        {
+          'name': 'where',
+          'arguments': [{'condition': 'lesserOutput'}, {'trueValue,': 'whereTrueValue'}, {'falseValue': 'whereFalseValue'}],
+          'outputs': 'whereOutput'
+        },
+        {
+          'name': 'add',
+          'arguments': [{'a': 'lesserOutput'}, {'b,': 'AddInputB'}],
+          'outputs': 'addOutput'
+        },
+      ],
+      'expectedOutputs': {
+        'whereOutput': {
+          'data': [1.1],
+          'descriptor': {shape: [1], dataType: 'float32'}
+        },
+        'addOutput': {
+          'data': [2],
+          'descriptor': {shape: [1], dataType: 'uint8'}
+        }
+      }
+    }
+  },
 ];
 
 if (navigator.ml) {

--- a/third_party/blink/web_tests/external/wpt/webnn/conformance_tests/optimize_graph.https.any.js
+++ b/third_party/blink/web_tests/external/wpt/webnn/conformance_tests/optimize_graph.https.any.js
@@ -129,7 +129,7 @@ const optimizedgraphTests = [
     }
   },
   {
-    'name': 'Lesser + Where & output: [Less] -> Bool -> [Where] & [Less] -> [Cast] -> uint8(output)',
+    'name': 'Lesser output is consumed by Where and used as graph output',
     'graph': {
       'inputs': {
         'LesserInputA': {
@@ -174,7 +174,7 @@ const optimizedgraphTests = [
     }
   },
   {
-    'name': 'Lesser + Where & Add: [Less] -> Bool -> [Where] & [Less] -> Bool -> [Cast] -> uint8 -> [Add]',
+    'name': 'Lesser output is consumed by Where and Add',
     'graph': {
       'inputs': {
         'LesserInputA': {


### PR DESCRIPTION
Fix #217 
If a bool output operand is used as bool input and not used as uint8 input at the same time, it can skip inserting cast operator to/from uint8.

This is not the optimal solution (for example the original WebNN model):
```
    Less
    /   \
Where   Add   
```
Current optimized ONNX model:
```
Less
  | 
Cast ---
  |     |
Cast    |
  |     |
Where  Add   
```
Desired optimized ONNX model:
```
 Less
  |  \
  |   Cast 
  |     |
Where  Add   
```

If we want to optimize to the desired model, we need to check nodes before adding each node that support uint8 as input.  Such detailed  processing may cause maintenance challenges, especially when adding new operators. WDYT? @huningxin 