### PR TITLE
Allow to configure graph optimization level

### DIFF
--- a/content/browser/gpu/gpu_process_host.cc
+++ b/content/browser/gpu/gpu_process_host.cc
@@ -332,6 +332,7 @@ static const char* const kSwitchNames[] = {
     switches::kWebNNOrtUseOVModelCache,
     switches::kWebNNOrtLoggingLevel,
     switches::kWebNNOrtLibraryPath,
+    switches::kWebNNOrtGraphOptimizationLevel,
 #endif
 };
 

--- a/services/webnn/ort/context_impl_ort.cc
+++ b/services/webnn/ort/context_impl_ort.cc
@@ -56,6 +56,33 @@ constexpr char kOVDeviceGPU[] = "GPU";
 constexpr char kOVDeviceCPU[] = "CPU";
 constexpr char kOVDeviceNPU[] = "NPU";
 
+// If the user did not specify a graph optimization level, or if the specified
+// level is not recognized, return the default graph optimization level.
+GraphOptimizationLevel GetUserGraphOptimizationLevelOr(
+    GraphOptimizationLevel default_graph_optimization_level) {
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kWebNNOrtGraphOptimizationLevel)) {
+    std::string user_graph_optimization_level =
+        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
+            switches::kWebNNOrtGraphOptimizationLevel);
+    if (user_graph_optimization_level == "DISABLE_ALL") {
+      return ORT_DISABLE_ALL;
+    } else if (user_graph_optimization_level == "BASIC") {
+      return ORT_ENABLE_BASIC;
+    } else if (user_graph_optimization_level == "EXTENDED") {
+      return ORT_ENABLE_EXTENDED;
+    } else if (user_graph_optimization_level == "ALL") {
+      return ORT_ENABLE_ALL;
+    }
+
+    LOG(WARNING) << "[WebNN] Unrecognized graph optimization level: "
+                 << user_graph_optimization_level
+                 << ". Default level will be used.";
+  }
+
+  return default_graph_optimization_level;
+}
+
 }  // namespace
 
 // static
@@ -165,7 +192,8 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
     // backend.
     // https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#other-configuration-settings
     CALL_ORT_FUNC(ort_api->SetSessionGraphOptimizationLevel(
-        session_options.get(), GraphOptimizationLevel::ORT_DISABLE_ALL));
+        session_options.get(),
+        GetUserGraphOptimizationLevelOr(ORT_DISABLE_ALL)));
 
     scoped_trace.AddStep("Append OpenVINO execution provider");
     // OpenVINO related dlls are loaded by this call.
@@ -193,7 +221,8 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
     // 2 (extended optimization).
     // https://github.com/microsoft/onnxruntime/blob/89f8206ba4f1c22c39e0297fb55272e8ce8cd7d0/onnxruntime/core/session/inference_session.cc#L2003
     CALL_ORT_FUNC(ort_api->SetSessionGraphOptimizationLevel(
-        session_options.get(), GraphOptimizationLevel::ORT_ENABLE_ALL));
+        session_options.get(),
+        GetUserGraphOptimizationLevelOr(ORT_ENABLE_ALL)));
     const OrtDmlApi* ort_dml_api = GetOrtDmlApi();
     CHECK(ort_dml_api);
     // Currently use the default device_id=0, which is typically the primary
@@ -225,7 +254,8 @@ SessionOptions::Create(const mojom::CreateContextOptions::Device device_type) {
     // to apply layout optimizations (ORT_ENABLE_ALL).
     // https://onnxruntime.ai/docs/performance/model-optimizations/graph-optimizations.html#layout-optimizations
     CALL_ORT_FUNC(ort_api->SetSessionGraphOptimizationLevel(
-        session_options.get(), GraphOptimizationLevel::ORT_ENABLE_BASIC));
+        session_options.get(),
+        GetUserGraphOptimizationLevelOr(ORT_ENABLE_BASIC)));
   }
 
   return base::WrapRefCounted(new SessionOptions(std::move(session_options)));

--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -3595,7 +3595,7 @@ GraphBuilderOrt::AddMatMulOperation(
     attributes.push_back(model_editor_.CreateAttribute(
         /*name=*/"block_size", base::checked_cast<int64_t>(block_size)));
     model_editor_.AddNode(kOpTypeMatMulNBits, node, inputs, outputs,
-                          std::move(attributes), kMSDomainName);
+                          std::move(attributes), kMSDomain);
 
   } else {
     std::array<const char*, 2> inputs = {input_a.c_str(), input_b.c_str()};

--- a/services/webnn/ort/ort_model_editor.cc
+++ b/services/webnn/ort/ort_model_editor.cc
@@ -221,11 +221,12 @@ OrtModelEditor::BuildAndTakeModelInfo() {
   CHECK(IsSuccess(GetOrtModelEditorApi()->SetGraphOutputs(
       graph_.get(), graph_outputs.data(), graph_outputs.size())));
 
-  std::vector<const char*> domain_names = {kOrtDomainName, kMSDomainName};
-  std::vector<int32_t> opset_versions = {kOrtOpsetVersion,
-                                         kEPContextOpsetVersion};
+  std::vector<const char*> domain_names = {kOrtDomain, kMSDomain,
+                                           kMSNchwcDomain};
+  std::vector<int32_t> opset_versions = {
+      kOrtOpsetVersion, kEPContextOpsetVersion, kMSNchwcDomainOpsetVersion};
   if (base::FeatureList::IsEnabled(mojom::features::kWebNNOrtDml)) {
-    domain_names.push_back(kMSDmlDomainName);
+    domain_names.push_back(kMSDmlDomain);
     opset_versions.push_back(kMSDmlDomainOpsetVersion);
   }
 

--- a/services/webnn/ort/ort_model_editor.h
+++ b/services/webnn/ort/ort_model_editor.h
@@ -19,10 +19,11 @@ namespace webnn {
 namespace ort {
 
 // Domains
-constexpr char kOrtDomainName[] = "";
-constexpr char kMSDomainName[] = "com.microsoft";
+constexpr char kOrtDomain[] = "";
+constexpr char kMSDomain[] = "com.microsoft";
+constexpr char kMSNchwcDomain[] = "com.microsoft.nchwc";
 // DML fused operators.
-constexpr char kMSDmlDomainName[] = "com.microsoft.dml";
+constexpr char kMSDmlDomain[] = "com.microsoft.dml";
 // WebGPU EP needs NHWC layout.
 constexpr char kMSInternalNhwcDomain[] = "com.ms.internal.nhwc";
 
@@ -31,6 +32,7 @@ constexpr int32_t kOrtOpsetVersion = 21;
 // EPContext op is used for exporting the EP context cache model.
 // https://onnxruntime.ai/docs/execution-providers/EP-Context-Design.html#onnxruntime-ep-context-cache-feature-design
 constexpr int32_t kEPContextOpsetVersion = 1;
+constexpr int32_t kMSNchwcDomainOpsetVersion = 1;
 constexpr int32_t kMSDmlDomainOpsetVersion = 1;
 constexpr int32_t kMSInternalNhwcDomainOpsetVersion = 1;
 
@@ -100,7 +102,7 @@ class OrtModelEditor {
                base::span<const char*> input,
                base::span<const char*> output,
                std::vector<ScopedOrtOpAttr> attributes = {},
-               std::string_view domain_name = kOrtDomainName);
+               std::string_view domain_name = kOrtDomain);
 
   std::unique_ptr<ModelInfo> BuildAndTakeModelInfo();
 

--- a/services/webnn/webnn_switches.h
+++ b/services/webnn/webnn_switches.h
@@ -57,6 +57,12 @@ inline constexpr char kWebNNOrtLoggingLevel[] = "webnn-ort-logging-level";
 // Usage: --webnn-ort-library-path="C:\Program Files\ONNXRuntime-OVEP"
 // --allow-third-party-modules
 inline constexpr char kWebNNOrtLibraryPath[] = "webnn-ort-library-path";
+
+// Configure the ort graph optimization level of ONNX Runtime.
+// Usage: --webnn-ort-graph-optimization-level=ALL
+// Other levels could be "DISABLE_ALL", "BASIC" and "EXTENDED".
+inline constexpr char kWebNNOrtGraphOptimizationLevel[] =
+    "webnn-ort-graph-optimization-level";
 #endif  // BUILDFLAG(WEBNN_USE_ORT)
 
 }  // namespace switches


### PR DESCRIPTION
Currently, default behavior is:
OV EP uses `ORT_DISABLE_ALL` graph optimization level
default CPU EP uses  `ORT_ENABLE_BASIC`
DML EP uses `ORT_ENABLE_ALL`.

1. This PR allows users to configure it to override the default one, usage is:

```
// Configure the ort graph optimization level of ONNX Runtime.
// Usage: --webnn-ort-graph-optimization-level=ALL
// Other levels could be "DISABLE_ALL", "BASIC" and "EXTENDED".
```
If the user did not specify a graph optimization level, or if the specified level is not recognized, default graph optimization level will continue to be used.

2. This PR also adds a new domain "com.microsoft.nchwc" required by gazenet model, and updates the "DomainName" to "Domain"


