### PR TITLE
Use `CreateTensorWithDataAndDeleterAsOrtValue()` to allow ORT to free the weights no longer needed

### DIFF
--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -32,10 +32,10 @@ namespace {
 
 struct Session {
   Session(ScopedOrtEnv env,
-          ScopedOrtSession session,
-          std::vector<base::HeapArray<uint8_t>> external_data)
-      : external_data(std::move(external_data)),
-        env(std::move(env)),
+          std::unique_ptr<OrtModelEditor::WeightDeleter> weight_deleter,
+          ScopedOrtSession session)
+      : env(std::move(env)),
+        weight_deleter(std::move(weight_deleter)),
         session(std::move(session)) {}
   Session(const Session&) = delete;
   Session& operator=(const Session&) = delete;
@@ -43,12 +43,15 @@ struct Session {
 
   OrtSession* GetSession() { return session.get(); }
 
-  std::vector<base::HeapArray<uint8_t>> external_data;
-
   // `env` should be prior to `session`. That ensures releasing `env` after
   // releasing the session. This avoids unloading the providers DLLs being
   // used during `session` destruction.
   ScopedOrtEnv env;
+
+  // `weight_deleter` should be prior to `session` since `weight_deleter` will
+  // be used for deleting the weights when `session` is destroyed.
+  std::unique_ptr<OrtModelEditor::WeightDeleter> weight_deleter;
+
   ScopedOrtSession session;
 };
 
@@ -194,9 +197,9 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
   }
 
   scoped_trace.AddStep("Create compute resources");
-  auto compute_session =
-      base::WrapUnique(new Session(std::move(env), std::move(session),
-                                   std::move(model_info->external_data)));
+  auto compute_session = base::WrapUnique(
+      new Session(std::move(env), std::move(model_info->weight_deleter),
+                  std::move(session)));
 
   base::flat_map<std::string, std::string>
       operand_input_name_to_onnx_input_name;

--- a/services/webnn/ort/graph_impl_ort.cc
+++ b/services/webnn/ort/graph_impl_ort.cc
@@ -32,10 +32,10 @@ namespace {
 
 struct Session {
   Session(ScopedOrtEnv env,
-          std::unique_ptr<OrtModelEditor::WeightDeleter> weight_deleter,
+          std::unique_ptr<OrtModelEditor::WeightsDeleter> weights_deleter,
           ScopedOrtSession session)
       : env(std::move(env)),
-        weight_deleter(std::move(weight_deleter)),
+        weights_deleter(std::move(weights_deleter)),
         session(std::move(session)) {}
   Session(const Session&) = delete;
   Session& operator=(const Session&) = delete;
@@ -48,9 +48,9 @@ struct Session {
   // used during `session` destruction.
   ScopedOrtEnv env;
 
-  // `weight_deleter` should be prior to `session` since `weight_deleter` will
+  // `weights_deleter` should be prior to `session` since `weights_deleter` will
   // be used for deleting the weights when `session` is destroyed.
-  std::unique_ptr<OrtModelEditor::WeightDeleter> weight_deleter;
+  std::unique_ptr<OrtModelEditor::WeightsDeleter> weights_deleter;
 
   ScopedOrtSession session;
 };
@@ -198,7 +198,7 @@ GraphImplOrt::CreateAndBuildOnBackgroundThread(
 
   scoped_trace.AddStep("Create compute resources");
   auto compute_session = base::WrapUnique(
-      new Session(std::move(env), std::move(model_info->weight_deleter),
+      new Session(std::move(env), std::move(model_info->weights_deleter),
                   std::move(session)));
 
   base::flat_map<std::string, std::string>

--- a/services/webnn/ort/ort_model_editor.cc
+++ b/services/webnn/ort/ort_model_editor.cc
@@ -6,6 +6,7 @@
 
 #include <ranges>
 
+#include "base/logging.h"
 #include "base/notreached.h"
 #include "services/webnn/ort/error_ort.h"
 #include "services/webnn/ort/utils_ort.h"
@@ -15,7 +16,49 @@ namespace webnn {
 
 namespace ort {
 
-OrtModelEditor::ModelInfo::ModelInfo() = default;
+OrtModelEditor::WeightDeleter::WeightDeleter() {
+  const OrtApi* ort_api = GetOrtApi();
+  CHECK(IsSuccess(ort_api->CreateCpuMemoryInfo(
+      OrtDeviceAllocator, OrtMemTypeDefault,
+      ScopedOrtMemoryInfo::Receiver(cpu_memory_info).get())));
+
+  OrtAllocator::version = ORT_API_VERSION;
+  OrtAllocator::Info = [](const OrtAllocator* this_) -> const OrtMemoryInfo* {
+    return static_cast<const WeightDeleter*>(this_)->cpu_memory_info.get();
+  };
+  OrtAllocator::Free = [](OrtAllocator* this_, void* p) -> void {
+    static_cast<WeightDeleter*>(this_)->FreeImpl(p);
+  };
+  OrtAllocator::Alloc = [](OrtAllocator* /*this_*/, size_t /*size*/) -> void* {
+    NOTREACHED() << "[WebNN] OrtAllocator::Alloc() should never be called.";
+  };
+  OrtAllocator::Reserve = [](OrtAllocator* /*this_*/,
+                             size_t /*size*/) -> void* {
+    NOTREACHED() << "[WebNN] OrtAllocator::Reserve() should never be called.";
+  };
+}
+
+OrtModelEditor::WeightDeleter::~WeightDeleter() {
+  LOG_IF(FATAL, !weights.empty())
+      << "[WebNN] All the weights should be freed by ORT before "
+         "`WeightDeleter` is destroyed.";
+}
+
+void OrtModelEditor::WeightDeleter::Track(base::HeapArray<uint8_t> data) {
+  weights.push_back(std::move(data));
+}
+
+void OrtModelEditor::WeightDeleter::FreeImpl(void* p) {
+  // Exactly one element should be erased.
+  CHECK_EQ(std::erase_if(weights,
+                         [p](const base::HeapArray<uint8_t>& data) {
+                           return data.data() == p;
+                         }),
+           1u);
+}
+
+OrtModelEditor::ModelInfo::ModelInfo()
+    : weight_deleter(std::make_unique<WeightDeleter>()) {}
 OrtModelEditor::ModelInfo::~ModelInfo() = default;
 
 ScopedOrtValueInfo CreateOrtValueInfo(std::string_view name,
@@ -43,10 +86,6 @@ ScopedOrtValueInfo CreateOrtValueInfo(std::string_view name,
 }
 
 OrtModelEditor::OrtModelEditor() : model_info_(std::make_unique<ModelInfo>()) {
-  // WebNN constants are in CPU memory.
-  CHECK(IsSuccess(GetOrtApi()->CreateCpuMemoryInfo(
-      OrtDeviceAllocator, OrtMemTypeDefault,
-      ScopedOrtMemoryInfo::Receiver(memory_info_).get())));
   CHECK(IsSuccess(GetOrtModelEditorApi()->CreateGraph(
       ScopedOrtGraph::Receiver(graph_).get())));
 }
@@ -118,15 +157,16 @@ void OrtModelEditor::AddOutput(std::string_view name,
     ONNXTensorElementDataType data_type) {
   ScopedOrtValue initializer;
 
+  // TODO(https://github.com/shiyi9801/chromium/issues/49): Consider reusing
+  // constant operands instead of copying them.
   auto weight = base::HeapArray<uint8_t>::CopiedFrom(data);
-  model_info_->external_data.push_back(std::move(weight));
 
-  // TODO(https://github.com/shiyi9801/chromium/issues/45): Use
-  // `CreateTensorWithDataAndDeleterAsOrtValue()`.
-  RETURN_STATUS_IF_FAILED(GetOrtApi()->CreateTensorWithDataAsOrtValue(
-      memory_info_.get(), model_info_->external_data.back().data(),
-      model_info_->external_data.back().size(), shape.data(), shape.size(),
-      data_type, ScopedOrtValue::Receiver(initializer).get()));
+  RETURN_STATUS_IF_FAILED(GetOrtApi()->CreateTensorWithDataAndDeleterAsOrtValue(
+      model_info_->weight_deleter.get(), weight.data(), weight.size(),
+      shape.data(), shape.size(), data_type,
+      ScopedOrtValue::Receiver(initializer).get()));
+
+  model_info_->weight_deleter->Track(std::move(weight));
 
   // Graph will own the initializer.
   RETURN_STATUS_IF_FAILED(GetOrtModelEditorApi()->AddInitializerToGraph(

--- a/services/webnn/ort/ort_model_editor.cc
+++ b/services/webnn/ort/ort_model_editor.cc
@@ -16,18 +16,21 @@ namespace webnn {
 
 namespace ort {
 
-OrtModelEditor::WeightDeleter::WeightDeleter() {
+OrtModelEditor::WeightsDeleter::WeightsDeleter() {
   const OrtApi* ort_api = GetOrtApi();
   CHECK(IsSuccess(ort_api->CreateCpuMemoryInfo(
       OrtDeviceAllocator, OrtMemTypeDefault,
       ScopedOrtMemoryInfo::Receiver(cpu_memory_info).get())));
 
+  // `OrtAllocator` is a C-style structure (with a pointer to its definition),
+  // `Info` and `Free` are just function pointers that need to be set to lambda
+  // functions.
   OrtAllocator::version = ORT_API_VERSION;
   OrtAllocator::Info = [](const OrtAllocator* this_) -> const OrtMemoryInfo* {
-    return static_cast<const WeightDeleter*>(this_)->cpu_memory_info.get();
+    return static_cast<const WeightsDeleter*>(this_)->cpu_memory_info.get();
   };
   OrtAllocator::Free = [](OrtAllocator* this_, void* p) -> void {
-    static_cast<WeightDeleter*>(this_)->FreeImpl(p);
+    static_cast<WeightsDeleter*>(this_)->FreeImpl(p);
   };
   OrtAllocator::Alloc = [](OrtAllocator* /*this_*/, size_t /*size*/) -> void* {
     NOTREACHED() << "[WebNN] OrtAllocator::Alloc() should never be called.";
@@ -38,17 +41,17 @@ OrtModelEditor::WeightDeleter::WeightDeleter() {
   };
 }
 
-OrtModelEditor::WeightDeleter::~WeightDeleter() {
+OrtModelEditor::WeightsDeleter::~WeightsDeleter() {
   LOG_IF(FATAL, !weights.empty())
       << "[WebNN] All the weights should be freed by ORT before "
-         "`WeightDeleter` is destroyed.";
+         "`WeightsDeleter` is destroyed.";
 }
 
-void OrtModelEditor::WeightDeleter::Track(base::HeapArray<uint8_t> data) {
+void OrtModelEditor::WeightsDeleter::Take(base::HeapArray<uint8_t> data) {
   weights.push_back(std::move(data));
 }
 
-void OrtModelEditor::WeightDeleter::FreeImpl(void* p) {
+void OrtModelEditor::WeightsDeleter::FreeImpl(void* p) {
   // Exactly one element should be erased.
   CHECK_EQ(std::erase_if(weights,
                          [p](const base::HeapArray<uint8_t>& data) {
@@ -58,7 +61,7 @@ void OrtModelEditor::WeightDeleter::FreeImpl(void* p) {
 }
 
 OrtModelEditor::ModelInfo::ModelInfo()
-    : weight_deleter(std::make_unique<WeightDeleter>()) {}
+    : weights_deleter(std::make_unique<WeightsDeleter>()) {}
 OrtModelEditor::ModelInfo::~ModelInfo() = default;
 
 ScopedOrtValueInfo CreateOrtValueInfo(std::string_view name,
@@ -162,11 +165,11 @@ void OrtModelEditor::AddOutput(std::string_view name,
   auto weight = base::HeapArray<uint8_t>::CopiedFrom(data);
 
   RETURN_STATUS_IF_FAILED(GetOrtApi()->CreateTensorWithDataAndDeleterAsOrtValue(
-      model_info_->weight_deleter.get(), weight.data(), weight.size(),
+      model_info_->weights_deleter.get(), weight.data(), weight.size(),
       shape.data(), shape.size(), data_type,
       ScopedOrtValue::Receiver(initializer).get()));
 
-  model_info_->weight_deleter->Track(std::move(weight));
+  model_info_->weights_deleter->Take(std::move(weight));
 
   // Graph will own the initializer.
   RETURN_STATUS_IF_FAILED(GetOrtModelEditorApi()->AddInitializerToGraph(

--- a/services/webnn/ort/ort_model_editor.h
+++ b/services/webnn/ort/ort_model_editor.h
@@ -41,18 +41,18 @@ constexpr size_t kMinExternalDataSize = 128;
 
 class OrtModelEditor {
  public:
-  // The `WeightDeleter` is used by ORT to free the weights (external data) that
-  // is no longer in use. It should not be destroyed until all the weights are
-  // freed.
-  struct WeightDeleter : public OrtAllocator {
+  // The `WeightsDeleter` is used by ORT to free the weights (external data)
+  // that is no longer in use. It should not be destroyed until all the weights
+  // are freed.
+  struct WeightsDeleter : public OrtAllocator {
    public:
-    WeightDeleter();
-    WeightDeleter(const WeightDeleter&) = delete;
-    WeightDeleter& operator=(const WeightDeleter&) = delete;
-    ~WeightDeleter();
+    WeightsDeleter();
+    WeightsDeleter(const WeightsDeleter&) = delete;
+    WeightsDeleter& operator=(const WeightsDeleter&) = delete;
+    ~WeightsDeleter();
 
-    // Track the data to be freed by ORT.
-    void Track(base::HeapArray<uint8_t> data);
+    // Take the weights and keep it until being freed by ORT.
+    void Take(base::HeapArray<uint8_t> data);
 
    private:
     void FreeImpl(void* p);
@@ -71,7 +71,7 @@ class OrtModelEditor {
 
     // `weight_deleter` should be prior to `session` since `weight_deleter` will
     // be used for deleting the weights when `model` is destroyed.
-    std::unique_ptr<WeightDeleter> weight_deleter;
+    std::unique_ptr<WeightsDeleter> weights_deleter;
 
     ScopedOrtModel model;
   };

--- a/services/webnn/ort/ort_model_editor.h
+++ b/services/webnn/ort/ort_model_editor.h
@@ -41,19 +41,39 @@ constexpr size_t kMinExternalDataSize = 128;
 
 class OrtModelEditor {
  public:
+  // The `WeightDeleter` is used by ORT to free the weights (external data) that
+  // is no longer in use. It should not be destroyed until all the weights are
+  // freed.
+  struct WeightDeleter : public OrtAllocator {
+   public:
+    WeightDeleter();
+    WeightDeleter(const WeightDeleter&) = delete;
+    WeightDeleter& operator=(const WeightDeleter&) = delete;
+    ~WeightDeleter();
+
+    // Track the data to be freed by ORT.
+    void Track(base::HeapArray<uint8_t> data);
+
+   private:
+    void FreeImpl(void* p);
+
+    // The weights are always created on CPU.
+    ScopedOrtMemoryInfo cpu_memory_info;
+
+    std::vector<base::HeapArray<uint8_t>> weights;
+  };
+
   struct ModelInfo {
     ModelInfo();
     ModelInfo(const ModelInfo&) = delete;
     ModelInfo& operator=(const ModelInfo&) = delete;
     ~ModelInfo();
 
-    ScopedOrtModel model;
+    // `weight_deleter` should be prior to `session` since `weight_deleter` will
+    // be used for deleting the weights when `model` is destroyed.
+    std::unique_ptr<WeightDeleter> weight_deleter;
 
-    // TODO(https://github.com/shiyi9801/chromium/issues/49): Consider reusing
-    // constant operands instead of copying them to `external_data`.
-    //
-    // Store the external data which should be alive for inference session.
-    std::vector<base::HeapArray<uint8_t>> external_data;
+    ScopedOrtModel model;
   };
 
   OrtModelEditor();
@@ -110,7 +130,6 @@ class OrtModelEditor {
   std::vector<ScopedOrtValueInfo> inputs_;
   std::vector<ScopedOrtValueInfo> outputs_;
 
-  ScopedOrtMemoryInfo memory_info_;
   ScopedOrtGraph graph_;
 
   std::unique_ptr<ModelInfo> model_info_;


### PR DESCRIPTION
Fix #45

Tested this PR with SD turbo on both DML EP and CPU EP (no OV EP since it doesn't support the external data). For DML EP, it can release all the external data (~2.9GB) after the session is created (which is expected, since DML should upload the weights to GPU). For CPU EP, it almost releases none (only ~1MB as I observed).