### PR TITLE
Keep ’com.ms.internal.nhwc‘ domain opset version aligned with default ORT

### DIFF
--- a/services/webnn/ort/ort_model_editor.h
+++ b/services/webnn/ort/ort_model_editor.h
@@ -36,7 +36,7 @@ constexpr int32_t kOrtOpsetVersion = 21;
 constexpr int32_t kEPContextOpsetVersion = 1;
 constexpr int32_t kMSNchwcDomainOpsetVersion = 1;
 constexpr int32_t kMSDmlDomainOpsetVersion = 1;
-constexpr int32_t kMSInternalNhwcDomainOpsetVersion = 1;
+constexpr int32_t kMSInternalNhwcDomainOpsetVersion = 21;
 
 // Define the minimum size(in bytes) to use external data.
 constexpr size_t kMinExternalDataSize = 128;

--- a/services/webnn/ort/ort_model_editor.h
+++ b/services/webnn/ort/ort_model_editor.h
@@ -36,7 +36,7 @@ constexpr int32_t kOrtOpsetVersion = 21;
 constexpr int32_t kEPContextOpsetVersion = 1;
 constexpr int32_t kMSNchwcDomainOpsetVersion = 1;
 constexpr int32_t kMSDmlDomainOpsetVersion = 1;
-constexpr int32_t kMSInternalNhwcDomainOpsetVersion = 21;
+constexpr int32_t kMSInternalNhwcDomainOpsetVersion = kOrtOpsetVersion;
 
 // Define the minimum size(in bytes) to use external data.
 constexpr size_t kMinExternalDataSize = 128;


### PR DESCRIPTION
This PR fixes the issues that some operators such as ’BatchNormalization‘, ’InstanceNormalization‘ and ’averagePool2d‘ fail to run on ORT WebGPU EP.