### PR TITLE
Allow in-memory external weights for WebGPU EP

### DIFF
--- a/services/webnn/ort/graph_builder_ort.cc
+++ b/services/webnn/ort/graph_builder_ort.cc
@@ -1110,9 +1110,8 @@ base::expected<std::string, mojom::ErrorPtr> GraphBuilderOrt::CreateInitializer(
   ScopedOrtStatus status;
   // TODO(https://github.com/shiyi9801/chromium/issues/70,
   // https://github.com/shiyi9801/chromium/issues/209): Remove this workaround
-  // for OpenVINO and DML EP once the invalid external data issue is fixed.
-  if (!base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino) &&
-      !base::FeatureList::IsEnabled(mojom::features::kWebNNOrtWebGPU)) {
+  // for OpenVINO EP once the invalid external data issue is fixed.
+  if (!base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino)) {
     status = model_editor_.AddInitializer(name, int64_shape, byte_span,
                                           TensorTypeMap<DataType>::value);
 
@@ -1636,9 +1635,8 @@ GraphBuilderOrt::AddInitializer(uint64_t constant_id) {
   ScopedOrtStatus status;
   // TODO(https://github.com/shiyi9801/chromium/issues/70,
   // https://github.com/shiyi9801/chromium/issues/209): Remove this workaround
-  // for OpenVINO and DML EP once the invalid external data issue is fixed.
-  if (!base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino) &&
-      !base::FeatureList::IsEnabled(mojom::features::kWebNNOrtWebGPU)) {
+  // for OpenVINO EP once the invalid external data issue is fixed.
+  if (!base::FeatureList::IsEnabled(mojom::features::kWebNNOrtOpenVino)) {
     status = model_editor_.AddInitializer(
         name, std::move(constant_operands_.at(constant_id)));
   } else {


### PR DESCRIPTION
WebGPU EP supports in-memory external weights after fix:

https://github.com/microsoft/onnxruntime/commit/11f0a0a51179e1c28c9968daf5173de40681abec